### PR TITLE
fix: restore MCP schemas and domain email headers

### DIFF
--- a/packages/core/src/__tests__/parser.test.ts
+++ b/packages/core/src/__tests__/parser.test.ts
@@ -20,6 +20,24 @@ Hello, this is a test.`;
     expect(result.messageId).toBe('<test@example.com>');
   });
 
+  it('restores X-Original-From for inbound relay messages in domain mode', async () => {
+    const raw = `From: Ope <armand@agents.orbitalreach.space>
+To: armand@agents.orbitalreach.space
+Reply-To: ope.olatunji@outlook.com
+Subject: Re: Bug report
+Message-ID: <reply@example.com>
+X-AgenticMail-Relay: inbound
+X-Original-From: ope.olatunji@outlook.com
+Content-Type: text/plain
+
+Looks good.`;
+
+    const result = await parseEmail(raw);
+    expect(result.from[0].address).toBe('ope.olatunji@outlook.com');
+    expect(result.from[0].name).toBe('Ope');
+    expect(result.replyTo?.[0].address).toBe('ope.olatunji@outlook.com');
+  });
+
   it('parses an email with reply headers', async () => {
     const raw = `From: bob@example.com
 To: alice@example.com

--- a/packages/core/src/gateway/manager.ts
+++ b/packages/core/src/gateway/manager.ts
@@ -889,6 +889,8 @@ export class GatewayManager {
     const mailOpts: any = {
       from,
       to: recipients.join(', '),
+      cc: mail.cc ? (Array.isArray(mail.cc) ? mail.cc.join(', ') : mail.cc) : undefined,
+      bcc: mail.bcc ? (Array.isArray(mail.bcc) ? mail.bcc.join(', ') : mail.bcc) : undefined,
       subject: mail.subject,
       text: mail.text || undefined,
       html: mail.html || undefined,

--- a/packages/core/src/mail/parser.ts
+++ b/packages/core/src/mail/parser.ts
@@ -6,11 +6,13 @@ export async function parseEmail(raw: Buffer | string): Promise<ParsedEmail> {
 
   // Use X-Original-From header if present (inbound relay emails store the real sender there)
   const xOriginalFrom = parsed.headers?.get('x-original-from');
+  const xAgenticMailRelay = parsed.headers?.get('x-agenticmail-relay');
   const originalFromAddr = typeof xOriginalFrom === 'string' ? xOriginalFrom.trim() : undefined;
+  const isAgenticMailInboundRelay = xAgenticMailRelay === 'inbound';
 
   let fromAddrs = parsed.from?.value ?? [];
-  if (originalFromAddr && fromAddrs.length > 0 && fromAddrs[0].address?.endsWith('@localhost')) {
-    // Replace the @localhost address with the original external sender
+  if (originalFromAddr && fromAddrs.length > 0 && (isAgenticMailInboundRelay || fromAddrs[0].address?.endsWith('@localhost'))) {
+    // Replace the local relay address with the original external sender.
     fromAddrs = [{ name: fromAddrs[0].name || '', address: originalFromAddr }];
   }
 

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -7,8 +7,50 @@ import { resourceDefinitions, handleResourceRead } from './resources.js';
 import { setTelemetryVersion } from '@agenticmail/core';
 import { createServer } from 'node:http';
 import { randomUUID } from 'node:crypto';
+import { z, type ZodTypeAny } from 'zod';
 
 setTelemetryVersion('0.5.50');
+
+type JsonSchema = {
+  type?: string;
+  description?: string;
+  enum?: string[];
+  properties?: Record<string, JsonSchema | undefined>;
+  required?: string[];
+  items?: JsonSchema;
+};
+
+function jsonSchemaToZod(schema: JsonSchema | undefined, topLevel = false): Record<string, ZodTypeAny> | ZodTypeAny {
+  if (!schema || typeof schema !== 'object') return topLevel ? {} : z.any();
+
+  let result: ZodTypeAny;
+  if (schema.type === 'string') {
+    result = schema.enum?.length ? z.enum(schema.enum as [string, ...string[]]) : z.string();
+  } else if (schema.type === 'number' || schema.type === 'integer') {
+    result = z.number();
+  } else if (schema.type === 'boolean') {
+    result = z.boolean();
+  } else if (schema.type === 'array') {
+    // OpenAI-compatible validators reject arrays that serialize without an explicit items schema.
+    // z.any() round-trips to a naked array schema, so fallback to string for empty/absent items.
+    const hasItems = !!schema.items && typeof schema.items === 'object' && Object.keys(schema.items).length > 0;
+    result = z.array(hasItems ? jsonSchemaToZod(schema.items, false) as ZodTypeAny : z.string());
+  } else if (schema.type === 'object') {
+    const shape: Record<string, ZodTypeAny> = {};
+    const required = new Set(schema.required ?? []);
+    for (const [key, prop] of Object.entries(schema.properties ?? {})) {
+      let child = jsonSchemaToZod(prop, false) as ZodTypeAny;
+      if (!required.has(key)) child = child.optional();
+      shape[key] = child;
+    }
+    if (topLevel) return shape;
+    result = z.object(shape);
+  } else {
+    result = z.any();
+  }
+
+  return schema.description ? result.describe(schema.description) : result;
+}
 
 function createMcpServer(): McpServer {
   const server = new McpServer({
@@ -22,8 +64,8 @@ function createMcpServer(): McpServer {
     server.tool(
       tool.name,
       tool.description,
-      tool.inputSchema as any,
-      async ({ arguments: args }: { arguments: Record<string, unknown> }) => {
+      jsonSchemaToZod(tool.inputSchema, true) as any,
+      async (args: Record<string, unknown>) => {
         try {
           const result = await handleToolCall(tool.name, args as Record<string, unknown>);
           return { content: [{ type: 'text' as const, text: result }] };

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -852,7 +852,7 @@ export const toolDefinitions = [
         includeData: { type: 'boolean', description: 'For clone_table' },
         format: { type: 'string', description: 'For export: json|csv' },
         sql: { type: 'string', description: 'For sql/explain: raw SQL' },
-        params: { type: 'array', description: 'For sql/explain: query params' },
+        params: { type: 'array', items: { type: 'string' }, description: 'For sql/explain: query params' },
         includeShared: { type: 'boolean', description: 'For list_tables' },
         includeArchived: { type: 'boolean', description: 'For list_tables' },
       },


### PR DESCRIPTION
## Summary

Fixes four compatibility issues observed with AgenticMail in current MCP/OpenAI-compatible/domain-mode deployments:

- Convert tool JSON Schema definitions to Zod raw shapes before calling `server.tool()` so MCP SDK v1.12+ registers real input schemas instead of treating JSON Schema as annotations.
- Use direct MCP callback arguments (`async (args) =>`) instead of destructuring the pre-v1.12 wrapped `{ arguments }` shape.
- Ensure `storage.params` has an explicit non-empty array `items` schema so strict OpenAI-compatible validators do not reject the generated function parameters.
- Preserve `cc`/`bcc` in domain-mode `sendViaStalwart()` and restore `X-Original-From` for inbound AgenticMail relay messages in domain mode.

## Context

This was reproduced against `@agenticmail/mcp` with MCP SDK v1.12+ and strict OpenAI-compatible tool-schema validators. The initial symptom was `400 invalid_function_parameters`; after the JSON Schema/Zod fix, strict validators still rejected arrays that serialized without `items`.

A second domain-mode issue was found while verifying the report email: `cc` reached the API/gateway but was dropped in the Stalwart send path. A related inbound relay display issue made external replies appear as if they came from the agent because `parseEmail()` only restored `X-Original-From` when the rewritten sender ended with `@localhost`.

## Test plan

- [x] `npm run test --workspace=@agenticmail/core -- src/__tests__/parser.test.ts`
- [x] `npm run test --workspace=@agenticmail/core`
- [x] `npm run build --workspace=@agenticmail/core`
- [x] `npm run build --workspace=@agenticmail/mcp`
- [x] `npm run build`
