### PR TITLE
fix(gateway): guard mail.references with Array.isArray before .join

### DIFF
--- a/packages/core/src/gateway/manager.ts
+++ b/packages/core/src/gateway/manager.ts
@@ -262,7 +262,7 @@ export class GatewayManager {
         html: mail.html || undefined,
         replyTo: mail.from,
         inReplyTo: mail.inReplyTo,
-        references: mail.references?.join(' '),
+        references: Array.isArray(mail.references) ? mail.references.join(' ') : mail.references,
         headers: {
           'X-AgenticMail-Relay': 'inbound',
           'X-Original-From': mail.from,
@@ -894,7 +894,7 @@ export class GatewayManager {
       html: mail.html || undefined,
       replyTo: mail.replyTo || from,
       inReplyTo: mail.inReplyTo || undefined,
-      references: mail.references?.join(' ') || undefined,
+      references: Array.isArray(mail.references) ? mail.references.join(' ') : (mail.references || undefined),
       headers: {
         'X-Mailer': 'AgenticMail/1.0',
       },

--- a/packages/core/src/gateway/relay.ts
+++ b/packages/core/src/gateway/relay.ts
@@ -135,7 +135,7 @@ export class RelayGateway {
       html: mail.html,
       replyTo: relayFrom,
       inReplyTo: mail.inReplyTo,
-      references: mail.references?.join(' '),
+      references: Array.isArray(mail.references) ? mail.references.join(' ') : mail.references,
       headers: mail.headers,
       attachments: mail.attachments?.map((a) => ({
         filename: a.filename,


### PR DESCRIPTION
## Problem

`RelayGateway.sendViaRelay` (and two adjacent call sites) crash with
`TypeError: mail.references?.join is not a function` whenever
`mail.references` arrives as a string instead of an array.

In practice, that happens for every reply where the upstream caller
resolves a single `Message-Id` reference (common with single-message
threads), so the SMTP transport never sees the payload and the agent
silently fails to send the reply.

## Repro

Send any agent reply where the founder's original email has a single
`References` header — the relay throws and the reply never reaches Gmail.

## Fix

Three call sites in `packages/core/src` had the unguarded `mail.references?.join(' ')`
form, while two others (`gateway/manager.ts:411` and `mail/sender.ts:55`)
already had the proper `Array.isArray` guard. This aligns the remaining
three with the existing pattern:

```ts
references: Array.isArray(mail.references)
  ? mail.references.join(' ')
  : mail.references
```

Affected files:
- `packages/core/src/gateway/manager.ts` (lines 265, 897)
- `packages/core/src/gateway/relay.ts`   (line 138)

## Notes

- No new tests added — the existing `mail/sender.ts` already has the
  guarded form, so this is a one-line consistency fix rather than new
  behavior. Happy to add a regression test if maintainers prefer.
- No behavior change for callers passing arrays; previously-broken
  string-form callers now succeed.