### PR TITLE
Tighten CLI secret prompts and MCP API typing

### DIFF
--- a/agenticmail/src/cli.ts
+++ b/agenticmail/src/cli.ts
@@ -2088,7 +2088,7 @@ async function cmdOpenClaw() {
               if (gvEmail.trim() && gvEmail.toLowerCase().includes('@gmail.com')) {
                 log('');
                 log(`  ${c.dim('Get an app password at:')} ${c.cyan('https://myaccount.google.com/apppasswords')}`);
-                const gvPass = await ask(`  ${c.green(c.bold('App password for'))} ${c.bold(gvEmail.trim())}: `);
+                const gvPass = await askSecret(`  ${c.green(c.bold('App password for'))} ${c.bold(gvEmail.trim())}: `);
                 if (gvPass.trim()) {
                   forwardingEmail = gvEmail.trim();
                   forwardingPassword = gvPass.trim();
@@ -2122,7 +2122,7 @@ async function cmdOpenClaw() {
                   } else {
                     log('');
                     log(`  ${c.dim('Get an app password at:')} ${c.cyan('https://myaccount.google.com/apppasswords')}`);
-                    const gvPass = await ask(`  ${c.green(c.bold('App password for'))} ${c.bold(gvEmail.trim())}: `);
+                    const gvPass = await askSecret(`  ${c.green(c.bold('App password for'))} ${c.bold(gvEmail.trim())}: `);
                     if (gvPass.trim()) {
                       forwardingEmail = gvEmail.trim();
                       forwardingPassword = gvPass.trim();
@@ -2150,7 +2150,7 @@ async function cmdOpenClaw() {
             if (gvEmail.trim() && gvEmail.toLowerCase().includes('@gmail.com')) {
               log('');
               log(`  ${c.dim('Get an app password at:')} ${c.cyan('https://myaccount.google.com/apppasswords')}`);
-              const gvPass = await ask(`  ${c.green(c.bold('App password for'))} ${c.bold(gvEmail.trim())}: `);
+              const gvPass = await askSecret(`  ${c.green(c.bold('App password for'))} ${c.bold(gvEmail.trim())}: `);
               if (gvPass.trim()) {
                 forwardingEmail = gvEmail.trim();
                 forwardingPassword = gvPass.trim();

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -9,6 +9,10 @@ if (!API_KEY && !MASTER_KEY) {
   console.error('[agenticmail-mcp] Warning: Neither AGENTICMAIL_API_KEY nor AGENTICMAIL_MASTER_KEY is set');
 }
 
+type ApiJsonObject = Record<string, any>;
+type ApiJsonArray = any[];
+type ApiResponse = ApiJsonObject | ApiJsonArray | null;
+
 /** Build a check function that returns true if a pending email is still awaiting approval. */
 function makePendingCheck(pendingId: string): () => Promise<boolean> {
   return async () => {
@@ -33,7 +37,7 @@ function withReminders(text: string): string {
   return text + '\n\n' + reminders.map(r => r.message).join('\n\n');
 }
 
-async function apiRequest(method: string, path: string, body?: unknown, useMasterKey = false, timeoutMs = 30_000): Promise<any> {
+async function apiRequest<T extends ApiResponse = ApiJsonObject>(method: string, path: string, body?: unknown, useMasterKey = false, timeoutMs = 30_000): Promise<T> {
   const key = useMasterKey && MASTER_KEY ? MASTER_KEY : API_KEY;
   if (!key) {
     throw new Error(useMasterKey
@@ -60,12 +64,12 @@ async function apiRequest(method: string, path: string, body?: unknown, useMaste
   const contentType = response.headers.get('content-type');
   if (contentType?.includes('application/json')) {
     try {
-      return await response.json();
+      return await response.json() as T;
     } catch {
       throw new Error(`API returned invalid JSON from ${path}`);
     }
   }
-  return null;
+  return null as T;
 }
 
 export const toolDefinitions = [


### PR DESCRIPTION
This PR contains two small public-safe quality improvements:

- Google Voice app-password prompts in the CLI now use the existing masked secret prompt helper.
- The MCP package `apiRequest` helper is now generic and no longer exposes a direct `Promise<any>` return type.

Validation:

- `npm test`
- `npm run build`

No behavior change is intended for normal setup flow beyond masking secret input consistently.