### PR TITLE
Make OpenClaw inbox injection configurable

### DIFF
--- a/packages/openclaw/README.md
+++ b/packages/openclaw/README.md
@@ -332,11 +332,28 @@ The `openclaw.plugin.json` file registers the plugin with OpenClaw:
   "configSchema": {
     "apiUrl": { "type": "string", "default": "http://127.0.0.1:3100" },
     "apiKey": { "type": "string", "required": true },
-    "masterKey": { "type": "string" }
+    "masterKey": { "type": "string" },
+    "inboxInjectionMode": {
+      "type": "string",
+      "enum": ["off", "count", "summary", "required"],
+      "default": "summary"
+    },
+    "inboxInjectionMaxItems": { "type": "integer", "default": 5 },
+    "inboxInjectionIncludePreview": { "type": "boolean", "default": false }
   },
   "requires": { "bins": ["docker"] }
 }
 ```
+
+### Inbox Injection
+
+Unread inbox context is configurable:
+
+- `inboxInjectionMode: "off"` disables prompt injection
+- `inboxInjectionMode: "count"` injects only the unread count
+- `inboxInjectionMode: "summary"` injects sender, subject, and UID metadata
+- `inboxInjectionMode: "required"` preserves proactive read-first behavior
+- `inboxInjectionIncludePreview: true` adds a short message body preview
 
 ---
 
@@ -348,7 +365,9 @@ The plugin registers three OpenClaw lifecycle hooks:
 - Detects sub-agent sessions and provisions email accounts
 - Resolves parent agent email for auto-CC
 - Sends introduction email in coordination thread
-- Injects identity context, security rules, and unread mail summary into system prompt
+
+### before_prompt_build
+- Injects identity context, security rules, and unread mail context into system prompt
 
 ### before_tool_call
 - Injects sub-agent API keys for `agenticmail_*` tools

--- a/packages/openclaw/index.ts
+++ b/packages/openclaw/index.ts
@@ -2,6 +2,12 @@ import { registerTools, recordInboundAgentMessage, registerAgentIdentity, unregi
 import { initFollowUpSystem, cancelAllFollowUps } from './src/pending-followup.js';
 import { mailChannelPlugin } from './src/channel.js';
 import { createMailMonitorService } from './src/monitor.js';
+import {
+  formatUnreadInboxContext,
+  resolveInboxInjectionConfig,
+  sanitizeInboxPreview,
+  type UnreadMailSummary,
+} from './src/inbox-injection.js';
 import { setTelemetryVersion } from '@agenticmail/core';
 
 /** Minimum timeout (seconds) for sub-agents that have email capability */
@@ -185,6 +191,7 @@ function deriveAgentName(sessionKey: string): string {
 function activate(api: any): void {
   const config = api?.getConfig?.() ?? {};
   const pluginConfig = api?.pluginConfig ?? config;
+  const inboxInjectionConfig = resolveInboxInjectionConfig(pluginConfig);
 
   // Resolve OpenClaw agent identity for email From header
   let ownerName: string | undefined;
@@ -882,7 +889,7 @@ function activate(api: any): void {
 
     // --- Inbox awareness check ---
     // Skip for sub-agents in standard mode (task-focused, not checking mail)
-    if (!(isSubAgent && taskMode === 'standard') && agentApiKey) {
+    if (!(isSubAgent && taskMode === 'standard') && agentApiKey && inboxInjectionConfig.mode !== 'off') {
       try {
         const headers: Record<string, string> = { 'Authorization': `Bearer ${agentApiKey}` };
 
@@ -898,55 +905,49 @@ function activate(api: any): void {
           const uids: number[] = data?.uids ?? [];
 
           if (uids.length > 0) {
-            let myName = '';
-            try {
-              const meRes = await fetch(`${baseUrl}/accounts/me`, {
-                headers,
-                signal: AbortSignal.timeout(3_000),
-              });
-              if (meRes.ok) {
-                const me: any = await meRes.json();
-                myName = me?.name ?? '';
-              }
-            } catch { /* ignore */ }
+            const summaries: UnreadMailSummary[] = [];
 
-            const summaries: string[] = [];
-            for (const uid of uids.slice(0, 5)) {
+            if (inboxInjectionConfig.mode !== 'count') {
+              let myName = '';
               try {
-                const msgRes = await fetch(`${baseUrl}/mail/messages/${uid}`, {
+                const meRes = await fetch(`${baseUrl}/accounts/me`, {
                   headers,
-                  signal: AbortSignal.timeout(5_000),
+                  signal: AbortSignal.timeout(3_000),
                 });
-                if (!msgRes.ok) continue;
-                const msg: any = await msgRes.json();
-                const from = msg.from?.[0]?.address ?? 'unknown';
-                const subject = msg.subject ?? '(no subject)';
-                const isAgentMsg = from.endsWith('@localhost');
-                const tag = isAgentMsg ? '[agent]' : '[external]';
-                const preview = (msg.text ?? '').slice(0, 200).replace(/\n/g, ' ').trim();
-                summaries.push(`  - ${tag} UID ${uid}: from ${from} — "${subject}"${preview ? '\n    ' + preview : ''}`);
-
-                if (isAgentMsg && myName) {
-                  const senderName = from.split('@')[0] ?? '';
-                  if (senderName) recordInboundAgentMessage(senderName, myName);
+                if (meRes.ok) {
+                  const me: any = await meRes.json();
+                  myName = me?.name ?? '';
                 }
-              } catch { /* skip */ }
+              } catch { /* ignore */ }
+
+              for (const uid of uids.slice(0, inboxInjectionConfig.maxItems)) {
+                try {
+                  const msgRes = await fetch(`${baseUrl}/mail/messages/${uid}`, {
+                    headers,
+                    signal: AbortSignal.timeout(5_000),
+                  });
+                  if (!msgRes.ok) continue;
+                  const msg: any = await msgRes.json();
+                  const from = msg.from?.[0]?.address ?? 'unknown';
+                  const subject = msg.subject ?? '(no subject)';
+                  const isAgentMsg = from.endsWith('@localhost');
+                  summaries.push({
+                    uid,
+                    from,
+                    subject,
+                    tag: isAgentMsg ? 'agent' : 'external',
+                    preview: inboxInjectionConfig.includePreview ? sanitizeInboxPreview(msg.text) : undefined,
+                  });
+
+                  if (isAgentMsg && myName) {
+                    const senderName = from.split('@')[0] ?? '';
+                    if (senderName) recordInboundAgentMessage(senderName, myName);
+                  }
+                } catch { /* skip */ }
+              }
             }
 
-            if (summaries.length > 0) {
-              const more = uids.length > 5 ? `\n  (${uids.length - 5} more unread messages not shown)` : '';
-              prependLines.push(
-                '<unread-emails>',
-                `You have ${uids.length} unread email(s) in your inbox:`,
-                ...summaries,
-                more,
-                '',
-                'ACTION REQUIRED: You MUST read each unread email with agenticmail_read and briefly tell the user what it says.',
-                'Do this BEFORE responding to anything else. After reporting emails, continue with your original task.',
-                'Do NOT skip or defer reading emails — the user expects you to handle their inbox proactively.',
-                '</unread-emails>',
-              );
-            }
+            prependLines.push(...formatUnreadInboxContext(uids.length, summaries, inboxInjectionConfig));
           }
         }
       } catch {

--- a/packages/openclaw/openclaw.plugin.json
+++ b/packages/openclaw/openclaw.plugin.json
@@ -24,6 +24,24 @@
       "masterKey": {
         "type": "string",
         "description": "Master API key for admin operations (optional)"
+      },
+      "inboxInjectionMode": {
+        "type": "string",
+        "description": "Unread inbox context injection mode: off disables it, count shows only unread count, summary shows metadata summaries, required forces agents to read unread mail first",
+        "enum": ["off", "count", "summary", "required"],
+        "default": "summary"
+      },
+      "inboxInjectionMaxItems": {
+        "type": "integer",
+        "description": "Maximum unread messages to summarize in prompt context",
+        "minimum": 1,
+        "maximum": 25,
+        "default": 5
+      },
+      "inboxInjectionIncludePreview": {
+        "type": "boolean",
+        "description": "Include a short body preview in unread message summaries",
+        "default": false
       }
     },
     "required": ["apiKey"]

--- a/packages/openclaw/skill/SKILL.md
+++ b/packages/openclaw/skill/SKILL.md
@@ -241,4 +241,4 @@ Set in your OpenClaw config under `plugins.entries`:
 - **SMS / Phone** — Google Voice integration for verification codes and text messaging
 - **Database storage** — 28-action DBMS (DDL, DML, indexing, aggregation, import/export, raw SQL)
 - **Rate limiting** — Built-in protection against agent email storms
-- **Inbox awareness** — Agents are notified of unread mail at conversation start
+- **Configurable inbox awareness** — Agents can receive unread count, summaries, or required read-first prompts

--- a/packages/openclaw/src/__tests__/inbox-injection.test.ts
+++ b/packages/openclaw/src/__tests__/inbox-injection.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatUnreadInboxContext,
+  resolveInboxInjectionConfig,
+  sanitizeInboxPreview,
+} from '../inbox-injection.js';
+
+describe('resolveInboxInjectionConfig', () => {
+  it('uses safe summary defaults', () => {
+    expect(resolveInboxInjectionConfig(undefined)).toEqual({
+      mode: 'summary',
+      maxItems: 5,
+      includePreview: false,
+    });
+  });
+
+  it('accepts configured mode, max items, and preview flag', () => {
+    expect(resolveInboxInjectionConfig({
+      inboxInjectionMode: 'required',
+      inboxInjectionMaxItems: '12',
+      inboxInjectionIncludePreview: true,
+    })).toEqual({
+      mode: 'required',
+      maxItems: 12,
+      includePreview: true,
+    });
+  });
+
+  it('clamps item count and ignores invalid modes', () => {
+    expect(resolveInboxInjectionConfig({
+      inboxInjectionMode: 'always',
+      inboxInjectionMaxItems: 100,
+    })).toEqual({
+      mode: 'summary',
+      maxItems: 25,
+      includePreview: false,
+    });
+  });
+});
+
+describe('formatUnreadInboxContext', () => {
+  const summaries = [{
+    uid: 42,
+    from: 'agent@localhost',
+    subject: 'Status',
+    tag: 'agent' as const,
+  }];
+
+  it('does not emit message body previews by default', () => {
+    const lines = formatUnreadInboxContext(2, summaries, {
+      mode: 'summary',
+      maxItems: 5,
+      includePreview: false,
+    });
+
+    expect(lines.join('\n')).toContain('You have 2 unread email(s)');
+    expect(lines.join('\n')).toContain('Use agenticmail_read when an unread email is relevant');
+    expect(lines.join('\n')).not.toContain('ACTION REQUIRED');
+  });
+
+  it('supports count-only mode without summaries', () => {
+    const lines = formatUnreadInboxContext(3, summaries, {
+      mode: 'count',
+      maxItems: 5,
+      includePreview: false,
+    });
+
+    expect(lines.join('\n')).toContain('You have 3 unread email(s)');
+    expect(lines.join('\n')).not.toContain('UID 42');
+    expect(lines.join('\n')).not.toContain('ACTION REQUIRED');
+  });
+
+  it('keeps explicit required mode available', () => {
+    const lines = formatUnreadInboxContext(1, summaries, {
+      mode: 'required',
+      maxItems: 5,
+      includePreview: false,
+    });
+
+    expect(lines.join('\n')).toContain('ACTION REQUIRED');
+    expect(lines.join('\n')).toContain('Read each unread email');
+  });
+});
+
+describe('sanitizeInboxPreview', () => {
+  it('normalizes whitespace and caps previews', () => {
+    const preview = sanitizeInboxPreview(`one\n${'two '.repeat(80)}`);
+
+    expect(preview).toMatch(/^one two/);
+    expect(preview?.length).toBeLessThanOrEqual(200);
+  });
+});

--- a/packages/openclaw/src/inbox-injection.ts
+++ b/packages/openclaw/src/inbox-injection.ts
@@ -1,0 +1,106 @@
+export const INBOX_INJECTION_MODES = ['off', 'count', 'summary', 'required'] as const;
+
+export type InboxInjectionMode = typeof INBOX_INJECTION_MODES[number];
+
+export interface InboxInjectionConfig {
+  mode: InboxInjectionMode;
+  maxItems: number;
+  includePreview: boolean;
+}
+
+export interface UnreadMailSummary {
+  uid: number;
+  from: string;
+  subject: string;
+  tag: 'agent' | 'external';
+  preview?: string;
+}
+
+const DEFAULT_INBOX_INJECTION_CONFIG: InboxInjectionConfig = {
+  mode: 'summary',
+  maxItems: 5,
+  includePreview: false,
+};
+
+const MAX_INBOX_INJECTION_ITEMS = 25;
+
+function isInboxInjectionMode(value: unknown): value is InboxInjectionMode {
+  return typeof value === 'string' && INBOX_INJECTION_MODES.includes(value as InboxInjectionMode);
+}
+
+function resolvePositiveInteger(value: unknown, fallback: number): number {
+  const candidate = typeof value === 'string' && value.trim() !== ''
+    ? Number(value)
+    : value;
+
+  if (typeof candidate !== 'number' || !Number.isFinite(candidate)) return fallback;
+  return Math.min(MAX_INBOX_INJECTION_ITEMS, Math.max(1, Math.floor(candidate)));
+}
+
+export function resolveInboxInjectionConfig(config: Record<string, unknown> | undefined): InboxInjectionConfig {
+  return {
+    mode: isInboxInjectionMode(config?.inboxInjectionMode)
+      ? config.inboxInjectionMode
+      : DEFAULT_INBOX_INJECTION_CONFIG.mode,
+    maxItems: resolvePositiveInteger(
+      config?.inboxInjectionMaxItems,
+      DEFAULT_INBOX_INJECTION_CONFIG.maxItems,
+    ),
+    includePreview: config?.inboxInjectionIncludePreview === true,
+  };
+}
+
+export function sanitizeInboxPreview(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+
+  const preview = value.replace(/\s+/g, ' ').slice(0, 200).trim();
+  return preview || undefined;
+}
+
+function formatSummary(summary: UnreadMailSummary): string {
+  const preview = summary.preview ? `\n    ${summary.preview}` : '';
+  return `  - [${summary.tag}] UID ${summary.uid}: from ${summary.from}: "${summary.subject}"${preview}`;
+}
+
+export function formatUnreadInboxContext(
+  totalUnread: number,
+  summaries: UnreadMailSummary[],
+  config: InboxInjectionConfig,
+): string[] {
+  if (config.mode === 'off' || totalUnread <= 0) return [];
+
+  const lines = [
+    '<unread-emails>',
+    `You have ${totalUnread} unread email(s) in your inbox.`,
+  ];
+
+  if (config.mode === 'count') {
+    lines.push('Use agenticmail_inbox or agenticmail_read only when the current task requires checking mail.');
+    lines.push('</unread-emails>');
+    return lines;
+  }
+
+  if (summaries.length > 0) {
+    lines.push('Unread summary:');
+    lines.push(...summaries.map(formatSummary));
+
+    const remaining = totalUnread - summaries.length;
+    if (remaining > 0) lines.push(`  (${remaining} more unread messages not shown)`);
+  } else {
+    lines.push('Unread message summaries are unavailable.');
+  }
+
+  lines.push('');
+
+  if (config.mode === 'required') {
+    lines.push(
+      'ACTION REQUIRED: Read each unread email with agenticmail_read before responding.',
+      'Briefly tell the user what each unread email says, then continue with your original task.',
+    );
+  } else {
+    lines.push('Use agenticmail_read when an unread email is relevant to the current task.');
+  }
+
+  lines.push('</unread-emails>');
+  return lines;
+}


### PR DESCRIPTION
## Summary
- adds configurable OpenClaw unread inbox injection modes: off, count, summary, and required
- defaults to metadata summaries without body previews to reduce prompt noise
- keeps the previous read-first behavior available through explicit configuration
- documents the new plugin settings and adds focused Vitest coverage

## Verification
- npm test --workspace=@agenticmail/openclaw
- npm run build --workspace=@agenticmail/openclaw
- npm test
- npm run build
- npm run lint

Note: `npm run lint --workspace=@agenticmail/openclaw` is not available because that workspace has no lint script.