### PR TITLE
Classify inbound email route events

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ Two key types:
 | `DELETE` | `/accounts/:id` | Master | Delete agent (with email archival) |
 | `GET` | `/accounts/directory` | Both | Agent discovery directory |
 | **Events** | | | |
-| `GET` | `/events` | Agent | SSE stream — new email, flags, expunge events |
+| `GET` | `/events` | Agent | SSE stream — new email with route metadata, flags, expunge events |
 | **Gateway** | | | |
 | `GET` | `/gateway/status` | Both | Current gateway mode and health |
 | `POST` | `/gateway/relay` | Master | Configure relay mode |

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -104,9 +104,11 @@ When a new email lands in an agent's inbox, the system does several things in re
 
 2. **Spam scoring** — external emails are scored. If the score exceeds the spam threshold, the email is automatically moved to the Spam folder and the notification event includes spam details. If it's a warning (elevated but not spam), the event includes the warning info but the email stays in the inbox.
 
-3. **Rule evaluation** — after spam filtering, the system checks the agent's custom email rules. Rules are checked in priority order and the first match wins. A rule can auto-mark the email as read, delete it, or move it to a specific folder.
+3. **Route classification** — the event is tagged with a route class such as `ignore_spam`, `ignore_newsletter`, `archive_automated`, `project_update`, `deal_escalation`, or `agent_instruction`. The route also includes the suggested action and whether a human gate is required.
 
-4. **Notification sent** — the event is pushed to all of the agent's connected SSE streams.
+4. **Rule evaluation** — after spam filtering, the system checks the agent's custom email rules. Rules are checked in priority order and the first match wins. A rule can auto-mark the email as read, delete it, or move it to a specific folder.
+
+5. **Notification sent** — the event is pushed to all of the agent's connected SSE streams.
 
 ### Connection limits
 

--- a/packages/api/src/routes/events.ts
+++ b/packages/api/src/routes/events.ts
@@ -6,8 +6,7 @@ import {
   parseEmail,
   scoreEmail,
   isInternalEmail,
-  SPAM_THRESHOLD,
-  WARNING_THRESHOLD,
+  classifyEmailRoute,
   type AccountManager,
   type AgenticMailConfig,
 } from '@agenticmail/core';
@@ -134,6 +133,12 @@ export function createEventRoutes(accountManager: AccountManager, config: Agenti
             try {
               const raw = await receiver.fetchMessage(event.uid);
               const parsed = await parseEmail(raw);
+              const accountRouteContext = {
+                name: agent.name,
+                email: agent.email,
+                role: agent.role,
+                metadata: agent.metadata,
+              };
 
               // --- Spam filter (runs BEFORE rules, skipped for internal emails) ---
               // Relay-delivered emails have X-AgenticMail-Relay header — they are
@@ -141,6 +146,8 @@ export function createEventRoutes(accountManager: AccountManager, config: Agenti
               const isRelay = !!parsed.headers.get('x-agenticmail-relay');
               const internal = !isRelay && isInternalEmail(parsed);
               if (internal) {
+                (event as any).route = classifyEmailRoute({ email: parsed, account: accountRouteContext });
+
                 // Internal agent-to-agent email — skip spam filter entirely
                 const ruleResult = evaluateRules(db, agent.id, parsed);
                 if (ruleResult) {
@@ -155,6 +162,8 @@ export function createEventRoutes(accountManager: AccountManager, config: Agenti
               }
 
               const spamResult = scoreEmail(parsed);
+              (event as any).route = classifyEmailRoute({ email: parsed, spam: spamResult, account: accountRouteContext });
+
               // Log to spam_log
               try {
                 db.prepare(

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -28,7 +28,7 @@ Every other AgenticMail package depends on this one.
 
 ## What This Package Does
 
-AgenticMail Core provides 15 major components organized into modules:
+AgenticMail Core provides 16 major components organized into modules:
 
 ### Agent Management
 - **AccountManager** — Creates, lists, finds, and deletes AI agent accounts. Each agent gets their own email address, login credentials, and a unique API key. Agent names must be email-safe (letters, numbers, dots, hyphens, underscores only).
@@ -58,6 +58,7 @@ AgenticMail Core provides 15 major components organized into modules:
 - **scanOutboundEmail** — Scans every outgoing email before it's sent, looking for sensitive data that an AI agent shouldn't be leaking. Detects API keys (AWS, OpenAI, GitHub, Stripe, and many more), passwords, private keys (SSH, PGP, RSA), personally identifiable information (Social Security numbers, credit card numbers, bank account numbers, passport numbers, dates of birth, driver's licenses), database connection strings, JWT tokens, cryptocurrency wallet addresses, webhook URLs, environment variable blocks, and more. Also checks attachment filenames for risky file types. If any high-severity match is found, the email is blocked. Emails between local agents (`@localhost` recipients) skip scanning entirely.
 - **sanitizeEmail** — Cleans up incoming email HTML to remove hidden content that could be used for prompt injection or phishing. Strips invisible Unicode characters (tag characters, zero-width joiners, bidirectional controls, soft hyphens), removes hidden HTML elements (display:none, visibility:hidden, font-size:0, white-on-white text, off-screen positioned elements, hidden iframes), removes script tags, strips data: and javascript: URIs, and removes suspicious HTML comments that contain words like "ignore", "system", "instruction", or "prompt". Returns both the cleaned content and a list of everything it found and removed.
 - **scoreEmail** — Scores incoming email for spam and threat indicators using 47 pattern-matching rules across 9 categories. Returns a numeric score (0-100), whether it's classified as spam (score 40+) or a warning (score 20-39), the top threat category, and a list of every rule that matched with its score contribution.
+- **classifyEmailRoute** — Assigns incoming mail a route class such as `ignore_spam`, `ignore_newsletter`, `archive_automated`, `project_update`, `deal_escalation`, or `agent_instruction`. The classification includes the suggested action, confidence, reason, and whether a human gate is required before downstream action.
 - **isInternalEmail** — Detects whether an email is from another local agent (agent-to-agent communication on `@localhost`). Importantly, it recognizes relay emails — if the "from" address is `@localhost` but the reply-to address is external, it's a forwarded relay email and should be treated as external, not internal.
 - **buildInboundSecurityAdvisory** — Analyzes incoming email attachments and spam matches to build a structured security advisory with risk levels (critical, high, medium) for attachments, double-extension detection (like `invoice.pdf.exe`), and link warnings.
 

--- a/packages/core/src/__tests__/route-classifier.test.ts
+++ b/packages/core/src/__tests__/route-classifier.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { classifyEmailRoute } from '../mail/route-classifier.js';
+import type { ParsedEmail } from '../mail/types.js';
+
+function email(overrides: Partial<ParsedEmail> = {}): ParsedEmail {
+  return {
+    messageId: 'm1',
+    subject: 'Project update',
+    from: [{ address: 'sender@example.com' }],
+    to: [{ address: 'agent@localhost' }],
+    date: new Date('2026-05-07T00:00:00Z'),
+    text: 'Here is the latest update.',
+    attachments: [],
+    headers: new Map(),
+    ...overrides,
+  };
+}
+
+describe('classifyEmailRoute', () => {
+  it('routes spam to ignore_spam', () => {
+    const route = classifyEmailRoute({
+      email: email(),
+      spam: { score: 45, isSpam: true, isWarning: false, topCategory: 'phishing' },
+    });
+
+    expect(route.routeClass).toBe('ignore_spam');
+    expect(route.action).toBe('ignore');
+    expect(route.gateRequired).toBe(false);
+  });
+
+  it('respects human/private mailbox policy', () => {
+    const route = classifyEmailRoute({
+      email: email(),
+      account: { metadata: { emailRoutePolicy: 'private' } },
+    });
+
+    expect(route.routeClass).toBe('human_private');
+    expect(route.action).toBe('notify');
+    expect(route.gateRequired).toBe(true);
+  });
+
+  it('routes newsletters to ignore_newsletter', () => {
+    const route = classifyEmailRoute({
+      email: email({
+        headers: new Map([['List-Unsubscribe', '<mailto:unsubscribe@example.com>']]),
+      }),
+    });
+
+    expect(route.routeClass).toBe('ignore_newsletter');
+    expect(route.action).toBe('ignore');
+  });
+
+  it('routes automated notifications to archive_automated', () => {
+    const route = classifyEmailRoute({
+      email: email({
+        subject: 'Build notification',
+        from: [{ address: 'no-reply@example.com' }],
+      }),
+    });
+
+    expect(route.routeClass).toBe('archive_automated');
+    expect(route.action).toBe('archive');
+  });
+
+  it('routes internal instructions to agent_instruction', () => {
+    const route = classifyEmailRoute({
+      email: email({
+        subject: 'Task',
+        from: [{ address: 'coordinator@localhost' }],
+        text: 'Please research this and send a summary.',
+      }),
+    });
+
+    expect(route.routeClass).toBe('agent_instruction');
+    expect(route.action).toBe('create_task');
+    expect(route.gateRequired).toBe(true);
+  });
+
+  it('routes commercial urgency to deal_escalation', () => {
+    const route = classifyEmailRoute({
+      email: email({
+        subject: 'Contract deadline',
+        text: 'We need pricing and a signed proposal by Friday.',
+      }),
+    });
+
+    expect(route.routeClass).toBe('deal_escalation');
+    expect(route.action).toBe('escalate');
+    expect(route.gateRequired).toBe(true);
+  });
+
+  it('defaults regular mail to project_update', () => {
+    const route = classifyEmailRoute({ email: email() });
+
+    expect(route.routeClass).toBe('project_update');
+    expect(route.action).toBe('notify');
+    expect(route.gateRequired).toBe(false);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,6 +35,7 @@ export type {
 
 // Spam Filter & Sanitizer
 export { scoreEmail, isInternalEmail, type SpamResult, type SpamRuleMatch, type SpamCategory, SPAM_THRESHOLD, WARNING_THRESHOLD } from './mail/spam-filter.js';
+export { classifyEmailRoute, type EmailRouteClassification, type EmailRouteClass, type EmailRouteAction, type EmailRouteInput } from './mail/route-classifier.js';
 export { sanitizeEmail, type SanitizeResult, type SanitizeDetection } from './mail/sanitizer.js';
 
 // Outbound Guard

--- a/packages/core/src/mail/route-classifier.ts
+++ b/packages/core/src/mail/route-classifier.ts
@@ -1,0 +1,214 @@
+import type { ParsedEmail } from './types.js';
+import type { SpamResult } from './spam-filter.js';
+
+export type EmailRouteClass =
+  | 'ignore_spam'
+  | 'ignore_newsletter'
+  | 'archive_automated'
+  | 'project_update'
+  | 'deal_escalation'
+  | 'agent_instruction'
+  | 'human_private';
+
+export type EmailRouteAction =
+  | 'ignore'
+  | 'archive'
+  | 'notify'
+  | 'escalate'
+  | 'create_task'
+  | 'draft_reply';
+
+export interface EmailRouteAccountContext {
+  name?: string;
+  email?: string;
+  role?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface EmailRouteInput {
+  email: ParsedEmail;
+  spam?: Pick<SpamResult, 'score' | 'isSpam' | 'isWarning' | 'topCategory'>;
+  account?: EmailRouteAccountContext;
+}
+
+export interface EmailRouteClassification {
+  routeClass: EmailRouteClass;
+  action: EmailRouteAction;
+  gateRequired: boolean;
+  confidence: 'low' | 'medium' | 'high';
+  reason: string;
+}
+
+const DEAL_TERMS = [
+  'contract', 'proposal', 'quote', 'pricing', 'price', 'budget',
+  'purchase order', 'invoice', 'deal', 'renewal', 'msa', 'sow',
+  'deadline', 'urgent', 'asap', 'time sensitive',
+];
+
+const INSTRUCTION_TERMS = [
+  'task', 'instruction', 'please', 'can you', 'could you', 'follow up',
+  'draft', 'reply', 'send', 'research', 'summarize', 'investigate',
+  'action item', 'todo',
+];
+
+const AUTOMATION_SUBJECT_TERMS = [
+  'receipt', 'notification', 'alert', 'build', 'deployment', 'backup',
+  'statement', 'verification code', 'security code', 'login code',
+];
+
+function normalize(value: string | undefined): string {
+  return (value ?? '').toLowerCase();
+}
+
+function textFor(email: ParsedEmail): string {
+  return `${email.subject ?? ''}\n${email.text ?? ''}\n${email.html ?? ''}`.toLowerCase();
+}
+
+function firstAddress(email: ParsedEmail): string {
+  return normalize(email.from[0]?.address);
+}
+
+function header(email: ParsedEmail, name: string): string {
+  const wanted = name.toLowerCase();
+  for (const [key, value] of email.headers) {
+    if (key.toLowerCase() === wanted) return normalize(value);
+  }
+  return '';
+}
+
+function localPart(address: string): string {
+  return address.split('@')[0] ?? '';
+}
+
+function containsAny(text: string, terms: string[]): boolean {
+  return terms.some(term => text.includes(term));
+}
+
+function accountPolicy(account: EmailRouteAccountContext | undefined): string {
+  const metadata = account?.metadata ?? {};
+  const value = metadata.emailRoutePolicy ?? metadata.routePolicy ?? metadata.mailboxPolicy;
+  return typeof value === 'string' ? value.toLowerCase() : '';
+}
+
+function isInternalAddress(address: string): boolean {
+  return address.endsWith('@localhost');
+}
+
+function isNewsletter(email: ParsedEmail): boolean {
+  const from = firstAddress(email);
+  const subjectAndBody = textFor(email);
+
+  return Boolean(
+    header(email, 'list-unsubscribe') ||
+    header(email, 'list-id') ||
+    header(email, 'x-campaign-id') ||
+    header(email, 'x-mailchimp-campaign') ||
+    header(email, 'precedence') === 'list' ||
+    localPart(from).includes('newsletter') ||
+    subjectAndBody.includes('unsubscribe') ||
+    subjectAndBody.includes('newsletter') ||
+    subjectAndBody.includes('weekly digest'),
+  );
+}
+
+function isAutomated(email: ParsedEmail): boolean {
+  const from = firstAddress(email);
+  const subject = normalize(email.subject);
+  const precedence = header(email, 'precedence');
+  const autoSubmitted = header(email, 'auto-submitted');
+
+  return Boolean(
+    (autoSubmitted && autoSubmitted !== 'no') ||
+    precedence === 'bulk' ||
+    precedence === 'auto' ||
+    localPart(from).includes('no-reply') ||
+    localPart(from).includes('noreply') ||
+    localPart(from).includes('donotreply') ||
+    containsAny(subject, AUTOMATION_SUBJECT_TERMS),
+  );
+}
+
+export function classifyEmailRoute(input: EmailRouteInput): EmailRouteClassification {
+  const { email, spam, account } = input;
+  const policy = accountPolicy(account);
+  const from = firstAddress(email);
+  const allText = textFor(email);
+
+  if (spam?.isSpam) {
+    return {
+      routeClass: 'ignore_spam',
+      action: 'ignore',
+      gateRequired: false,
+      confidence: 'high',
+      reason: `Spam score ${spam.score} exceeded the spam threshold`,
+    };
+  }
+
+  if (policy === 'human' || policy === 'private') {
+    return {
+      routeClass: 'human_private',
+      action: 'notify',
+      gateRequired: true,
+      confidence: 'high',
+      reason: 'Account policy marks this mailbox as human/private',
+    };
+  }
+
+  if (isNewsletter(email)) {
+    return {
+      routeClass: 'ignore_newsletter',
+      action: 'ignore',
+      gateRequired: false,
+      confidence: 'high',
+      reason: 'Newsletter headers or unsubscribe signals were detected',
+    };
+  }
+
+  if (isAutomated(email) && !containsAny(allText, DEAL_TERMS)) {
+    return {
+      routeClass: 'archive_automated',
+      action: 'archive',
+      gateRequired: false,
+      confidence: 'medium',
+      reason: 'Automated sender or notification pattern detected',
+    };
+  }
+
+  if ((policy === 'agent' || isInternalAddress(from)) && containsAny(allText, INSTRUCTION_TERMS)) {
+    return {
+      routeClass: 'agent_instruction',
+      action: 'create_task',
+      gateRequired: true,
+      confidence: isInternalAddress(from) ? 'high' : 'medium',
+      reason: 'Instruction-like content for an agent mailbox was detected',
+    };
+  }
+
+  if (containsAny(allText, DEAL_TERMS)) {
+    return {
+      routeClass: 'deal_escalation',
+      action: 'escalate',
+      gateRequired: true,
+      confidence: 'medium',
+      reason: 'Commercial, deadline, or negotiation language was detected',
+    };
+  }
+
+  if (spam?.isWarning) {
+    return {
+      routeClass: 'project_update',
+      action: 'notify',
+      gateRequired: true,
+      confidence: 'low',
+      reason: `Spam warning category ${spam.topCategory ?? 'unknown'} requires cautious handling`,
+    };
+  }
+
+  return {
+    routeClass: 'project_update',
+    action: 'notify',
+    gateRequired: false,
+    confidence: 'low',
+    reason: 'Default route for non-spam, non-automated email',
+  };
+}


### PR DESCRIPTION
## Summary
- adds a core `classifyEmailRoute` helper for inbound mail route classes
- tags new-mail SSE events with route metadata, suggested action, confidence, reason, and human gate requirement
- covers spam, newsletters, automated notifications, commercial escalations, agent instructions, private mailbox policy, and default project updates
- documents the route metadata and adds focused classifier tests

## Verification
- npm test --workspace=@agenticmail/core
- npm run build --workspace=@agenticmail/core
- npm run build --workspace=@agenticmail/api
- npm test
- npm run build
- npm run lint