### PR TITLE
fix(openclaw): make spawn timeout configurable

### DIFF
--- a/packages/openclaw/README.md
+++ b/packages/openclaw/README.md
@@ -113,6 +113,7 @@ The plugin registers email as an OpenClaw channel, which means:
 | `apiUrl` | No | `http://127.0.0.1:3829` | AgenticMail API URL |
 | `apiKey` | Yes | — | Agent API key (`ak_...`). Determines which agent this plugin acts as. |
 | `masterKey` | No | — | Master key (`mk_...`). Required for admin operations. |
+| `spawnMinTimeoutSeconds` | No | `600` | Minimum `runTimeoutSeconds` enforced for `sessions_spawn`; set `0` to disable timeout changes. |
 
 Plugin configuration lives in `~/.openclaw/openclaw.json` (user config), not in OpenClaw's source directory. Updating OpenClaw does not affect your AgenticMail plugin setup.
 
@@ -349,7 +350,8 @@ The `openclaw.plugin.json` file registers the plugin with OpenClaw:
       "default": "summary"
     },
     "inboxInjectionMaxItems": { "type": "integer", "default": 5 },
-    "inboxInjectionIncludePreview": { "type": "boolean", "default": false }
+    "inboxInjectionIncludePreview": { "type": "boolean", "default": false },
+    "spawnMinTimeoutSeconds": { "type": "integer", "minimum": 0, "default": 600 }
   },
   "requires": { "bins": ["docker"] }
 }
@@ -364,6 +366,7 @@ Unread inbox context is configurable:
 - `inboxInjectionMode: "summary"` injects sender, subject, and UID metadata
 - `inboxInjectionMode: "required"` preserves proactive read-first behavior
 - `inboxInjectionIncludePreview: true` adds a short message body preview
+- `spawnMinTimeoutSeconds: 60` allows short `sessions_spawn` calls; `0` disables timeout changes entirely
 
 ---
 
@@ -382,7 +385,7 @@ The plugin registers three OpenClaw lifecycle hooks:
 ### before_tool_call
 - Injects sub-agent API keys for `agenticmail_*` tools
 - Pushes pending email notifications from SSE watchers
-- Captures spawn info from `sessions_spawn` (enforces minimum 10-minute timeout)
+- Captures spawn info from `sessions_spawn` and applies the configured minimum timeout
 
 ### agent_end
 - Cancels all pending follow-up reminders

--- a/packages/openclaw/REFERENCE.md
+++ b/packages/openclaw/REFERENCE.md
@@ -160,6 +160,10 @@ Check the status of pending outbound emails that were blocked by the outbound gu
 
 ## Setup & Configuration
 
+### Plugin configuration
+
+The plugin reads configuration from the OpenClaw plugin entry. `spawnMinTimeoutSeconds` controls whether the `before_tool_call` hook raises low `sessions_spawn` timeouts. The default is `600` seconds for compatibility; set a lower positive value to allow quick sub-agent calls, or `0` to disable timeout changes.
+
 ### `agenticmail_setup_guide`
 Get a comparison of email setup modes (Relay vs Domain) with difficulty levels, requirements, and step-by-step instructions. Show this to users who want to set up real internet email to help them choose the right mode..
 
@@ -214,4 +218,3 @@ Get the current SMS/phone number configuration for this agent. Shows whether SMS
 
 ### `agenticmail_storage`
 Full database management for agents. Create/alter/drop tables, CRUD rows, manage indexes, run aggregations, import/export data, execute raw SQL, optimize & analyze — all on whatever database the user deployed (SQLite, Postgres, MySQL, Turso).
-

--- a/packages/openclaw/index.ts
+++ b/packages/openclaw/index.ts
@@ -10,8 +10,42 @@ import {
 } from './src/inbox-injection.js';
 import { setTelemetryVersion } from '@agenticmail/core';
 
-/** Minimum timeout (seconds) for sub-agents that have email capability */
-const MIN_SUBAGENT_TIMEOUT_S = 600; // 10 minutes
+/** Default minimum timeout (seconds) for sub-agents that have email capability */
+export const DEFAULT_SUBAGENT_MIN_TIMEOUT_SECONDS = 600; // 10 minutes
+
+export function resolveSpawnMinTimeoutSeconds(config: Record<string, unknown> | undefined): number {
+  const raw = config?.spawnMinTimeoutSeconds;
+  if (raw === undefined || raw === null || raw === '') {
+    return DEFAULT_SUBAGENT_MIN_TIMEOUT_SECONDS;
+  }
+
+  const parsed = typeof raw === 'number'
+    ? raw
+    : typeof raw === 'string' && raw.trim() !== ''
+      ? Number(raw.trim())
+      : Number.NaN;
+
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return DEFAULT_SUBAGENT_MIN_TIMEOUT_SECONDS;
+  }
+
+  return Math.floor(parsed);
+}
+
+export function applySpawnMinTimeout(
+  params: Record<string, unknown>,
+  minTimeoutSeconds: number,
+): Record<string, unknown> | undefined {
+  if (minTimeoutSeconds <= 0) return undefined;
+
+  const currentTimeout = Number(params.runTimeoutSeconds) || 0;
+  if (currentTimeout >= minTimeoutSeconds) return undefined;
+
+  return {
+    ...params,
+    runTimeoutSeconds: minTimeoutSeconds,
+  };
+}
 
 /**
  * Sub-agent email account registry.
@@ -192,6 +226,7 @@ function activate(api: any): void {
   const config = api?.getConfig?.() ?? {};
   const pluginConfig = api?.pluginConfig ?? config;
   const inboxInjectionConfig = resolveInboxInjectionConfig(pluginConfig);
+  const spawnMinTimeoutSeconds = resolveSpawnMinTimeoutSeconds(pluginConfig);
 
   // Resolve OpenClaw agent identity for email From header
   let ownerName: string | undefined;
@@ -997,7 +1032,7 @@ function activate(api: any): void {
       return;
     }
 
-    // --- Capture spawn info & increase timeout for sub-agent spawns ---
+    // --- Capture spawn info & optionally increase timeout for sub-agent spawns ---
     // 1. Capture label + task so before_agent_start can use the label as the email
     //    account name and include the task in the auto-intro email
     // 2. Sub-agents with email need more time for waiting on responses
@@ -1009,14 +1044,9 @@ function activate(api: any): void {
       const task = typeof params.task === 'string' ? params.task : '';
       pendingSpawns.push({ label, task });
 
-      const currentTimeout = Number(params.runTimeoutSeconds) || 0;
-      if (currentTimeout < MIN_SUBAGENT_TIMEOUT_S) {
-        return {
-          params: {
-            ...params,
-            runTimeoutSeconds: MIN_SUBAGENT_TIMEOUT_S,
-          },
-        };
+      const timeoutParams = applySpawnMinTimeout(params, spawnMinTimeoutSeconds);
+      if (timeoutParams) {
+        return { params: timeoutParams };
       }
     }
   });

--- a/packages/openclaw/openclaw.plugin.json
+++ b/packages/openclaw/openclaw.plugin.json
@@ -42,6 +42,12 @@
         "type": "boolean",
         "description": "Include a short body preview in unread message summaries",
         "default": false
+      },
+      "spawnMinTimeoutSeconds": {
+        "type": "integer",
+        "description": "Minimum runTimeoutSeconds to enforce for sessions_spawn calls; set to 0 to disable timeout changes",
+        "minimum": 0,
+        "default": 600
       }
     },
     "required": ["apiKey"]

--- a/packages/openclaw/src/__tests__/spawn-timeout.test.ts
+++ b/packages/openclaw/src/__tests__/spawn-timeout.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applySpawnMinTimeout,
+  DEFAULT_SUBAGENT_MIN_TIMEOUT_SECONDS,
+  resolveSpawnMinTimeoutSeconds,
+} from '../../index.js';
+
+describe('resolveSpawnMinTimeoutSeconds', () => {
+  it('uses the 10-minute default when config is absent', () => {
+    expect(resolveSpawnMinTimeoutSeconds(undefined)).toBe(DEFAULT_SUBAGENT_MIN_TIMEOUT_SECONDS);
+    expect(resolveSpawnMinTimeoutSeconds({})).toBe(DEFAULT_SUBAGENT_MIN_TIMEOUT_SECONDS);
+  });
+
+  it('accepts lower configured minimums for quick sub-agent calls', () => {
+    expect(resolveSpawnMinTimeoutSeconds({ spawnMinTimeoutSeconds: 60 })).toBe(60);
+    expect(resolveSpawnMinTimeoutSeconds({ spawnMinTimeoutSeconds: '90' })).toBe(90);
+  });
+
+  it('allows zero to disable timeout enforcement', () => {
+    expect(resolveSpawnMinTimeoutSeconds({ spawnMinTimeoutSeconds: 0 })).toBe(0);
+    expect(resolveSpawnMinTimeoutSeconds({ spawnMinTimeoutSeconds: '0' })).toBe(0);
+  });
+
+  it('normalizes invalid values back to the safe default', () => {
+    expect(resolveSpawnMinTimeoutSeconds({ spawnMinTimeoutSeconds: -1 })).toBe(DEFAULT_SUBAGENT_MIN_TIMEOUT_SECONDS);
+    expect(resolveSpawnMinTimeoutSeconds({ spawnMinTimeoutSeconds: 'abc' })).toBe(DEFAULT_SUBAGENT_MIN_TIMEOUT_SECONDS);
+    expect(resolveSpawnMinTimeoutSeconds({ spawnMinTimeoutSeconds: '   ' })).toBe(DEFAULT_SUBAGENT_MIN_TIMEOUT_SECONDS);
+    expect(resolveSpawnMinTimeoutSeconds({ spawnMinTimeoutSeconds: true })).toBe(DEFAULT_SUBAGENT_MIN_TIMEOUT_SECONDS);
+  });
+});
+
+describe('applySpawnMinTimeout', () => {
+  it('raises lower timeouts to the configured minimum', () => {
+    expect(applySpawnMinTimeout({ task: 'work', runTimeoutSeconds: 30 }, 60)).toEqual({
+      task: 'work',
+      runTimeoutSeconds: 60,
+    });
+  });
+
+  it('leaves timeouts at or above the configured minimum unchanged', () => {
+    expect(applySpawnMinTimeout({ runTimeoutSeconds: 60 }, 60)).toBeUndefined();
+    expect(applySpawnMinTimeout({ runTimeoutSeconds: 120 }, 60)).toBeUndefined();
+  });
+
+  it('does not change timeout when enforcement is disabled', () => {
+    expect(applySpawnMinTimeout({ runTimeoutSeconds: 30 }, 0)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add `spawnMinTimeoutSeconds` plugin config with default `600`
- allow lower minimums for quick `sessions_spawn` use cases, or `0` to disable timeout rewriting
- keep the existing default behavior for compatibility
- document the config and cover the policy with OpenClaw tests

## Tests
- `npm test --workspace=@agenticmail/openclaw`
- `npm run build --workspace=@agenticmail/openclaw`

## Compatibility
Default behavior is unchanged. Existing installs still enforce a 600 second minimum unless the new config is set.