### PR TITLE
feat(sms): add EU provider registry and 46elks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,55 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.45] - 2026-05-18
+
+### Added — EU SMS provider registry + 46elks
+
+Community contribution from @benediktkraus ([#35](https://github.com/agenticmail/agenticmail/pull/35)).
+
+- **Provider registry** — SMS is now provider-backed. Google Voice
+  remains the default legacy provider; 46elks is the first direct-API
+  provider. `sms_setup` takes a `provider` argument across REST, MCP,
+  and OpenClaw.
+- **46elks integration** — direct outbound SMS through the 46elks API
+  (HTTP Basic auth, form-encoded), and a secret-protected inbound SMS
+  webhook (`POST /sms/webhook/46elks`) mounted before bearer auth.
+- **Credential redaction** — `GET /sms/config` and every setup
+  response now run through `redactSmsConfig`, so provider passwords
+  and webhook secrets never appear in API output.
+
+### Security — hardening applied during review of #35
+
+The feature was audited before merge; no malicious code was found.
+The following defense-in-depth changes were added on top:
+
+- **SMS credentials encrypted at rest.** The 46elks API password, the
+  inbound-webhook shared secret, and the Google Voice forwarding-mailbox
+  app password were being stored as plaintext in agent metadata.
+  `SmsManager` now encrypts those fields with the same AES-256-GCM +
+  scrypt scheme `GatewayManager` already uses for relay/domain
+  credentials. The cipher helpers were extracted into a shared
+  `crypto/secrets` module so both managers use one audited
+  implementation. Reads tolerate legacy plaintext, so the upgrade is
+  seamless; a leaked SQLite file no longer hands over working
+  provider credentials.
+- **Webhook number-enumeration oracle closed.** The inbound webhook
+  returned `404` for an unknown recipient number but `403` for a wrong
+  secret — letting an unauthenticated caller probe which phone numbers
+  are registered. It now returns a single uniform `403` for every
+  failure mode (unknown number, no configured secret, missing or wrong
+  secret). The secret check uses `timingSafeEqual`.
+- **`apiUrl` override forced to https.** A 46elks `apiUrl` override is
+  the endpoint the outbound call sends Basic-Auth credentials to.
+  `/sms/setup` now rejects any non-`https://` override, and the
+  provider re-checks the scheme at send time — credentials can't be
+  exfiltrated over plaintext or pointed at an arbitrary internal host.
+- **Webhook secret moved out of the URL.** Setup guidance now tells
+  operators to authenticate the inbound webhook with the
+  `x-46elks-secret` header (kept out of access logs); the query-param
+  form is documented only as a fallback for providers that can't send
+  custom headers.
+
 ## [0.9.39] - 2026-05-15
 
 ### Fixed — three rough edges from 0.9.38's `setup-email` shakedown

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ See [CHANGELOG.md](./CHANGELOG.md) for the full release history.
 
 ---
 
-AgenticMail is a self-hosted communication platform purpose-built for AI agents. It runs a local [Stalwart](https://stalw.art) mail server via Docker, integrates Google Voice for SMS/phone access, exposes a REST API with 75+ endpoints, ships a lightweight Gmail-style web UI for human oversight, and works with any MCP-compatible AI client and [OpenClaw](https://github.com/openclaw/openclaw) via plugin. Each agent gets its own email address, phone number, inbox, and API key.
+AgenticMail is a self-hosted communication platform purpose-built for AI agents. It runs a local [Stalwart](https://stalw.art) mail server via Docker, integrates SMS/phone access via Google Voice or 46elks, exposes a REST API with 75+ endpoints, ships a lightweight Gmail-style web UI for human oversight, and works with any MCP-compatible AI client and [OpenClaw](https://github.com/openclaw/openclaw) via plugin. Each agent gets its own email address, phone number, inbox, and API key.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
 [![Node.js](https://img.shields.io/badge/Node.js-22%2B-green)](https://nodejs.org)
@@ -133,7 +133,7 @@ AI agents need to communicate with the real world. Email is the universal commun
 - **Internet email connectivity** — two gateway modes to send/receive real email (Gmail relay or custom domain with DKIM/SPF/DMARC).
 - **Security guardrails** — outbound scanning prevents agents from leaking API keys, passwords, or PII. Blocked emails require human approval.
 - **Agent collaboration** — agents can email each other, assign tasks, and make synchronous RPC calls.
-- **SMS / Phone number access** — integrate Google Voice for SMS receive/send, verification code extraction, and phone number access for AI agents.
+- **SMS / Phone number access** — integrate Google Voice or 46elks for SMS receive/send, verification code extraction, and phone number access for AI agents.
 - **Smart orchestration** — `call_agent` replaces basic sub-agent spawning with auto mode detection, dynamic timeouts, runtime tool discovery, and async execution for long-running tasks.
 - **Tool integrations** — 62 MCP tools for any AI client, 63 OpenClaw tools, and a 44-command interactive shell.
 - **Self-updating** — `agenticmail update` checks npm, verifies OpenClaw compatibility, and updates both packages automatically.
@@ -215,12 +215,14 @@ That's a real multi-agent thread captured in the REPL — the host kicked off on
 - **Rate limiting** — configurable per-endpoint rate limits
 
 ### SMS / Phone Number Access
+- **Provider selection** — choose Google Voice legacy forwarding or 46elks direct SMS API/webhooks
+- **46elks integration** — send SMS through the provider API and receive inbound SMS through a secret-protected webhook
 - **Google Voice integration** — give agents a real phone number via Google Voice
 - **Direct Voice web reading** (primary, instant) — reads SMS directly from voice.google.com via browser
 - **Email forwarding** (fallback) — Google Voice forwards SMS to email, agent auto-detects and records them during relay polling
 - **Separate Gmail polling** — for users whose GV Gmail differs from relay email, runs a dedicated IMAP poll
 - **Verification codes** — automatic extraction of OTP/verification codes from SMS (4-8 digit, alphanumeric, Google G-codes)
-- **Send SMS** — record outbound messages, send via Google Voice web automation
+- **Send SMS** — direct provider API send when configured, or Google Voice web automation instructions for legacy configs
 - **Smart setup wizard** — validates Gmail/GV email matching, warns about mismatches, collects separate credentials when needed
 
 ### Smart Orchestration (call_agent)
@@ -367,7 +369,7 @@ npm install -g @agenticmail/cli
 agenticmail setup
 ```
 
-The wizard walks you through everything: dependency checks, master key generation, mail-server start, optional Gmail relay or custom domain, optional Google Voice SMS, optional OpenClaw integration. Re-runnable any time.
+The wizard walks you through everything: dependency checks, master key generation, mail-server start, optional Gmail relay or custom domain, optional SMS setup, optional OpenClaw integration. Re-runnable any time.
 
 ### Skip external email entirely?
 

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -214,7 +214,7 @@ export function createApp(configOverrides?: Partial<AgenticMailConfig>): {
   app.use('/api/agenticmail', createInboundRoutes(accountManager, config, gatewayManager));
 
   // Inbound SMS provider webhooks (use provider-specific secrets, before bearer auth)
-  app.use('/api/agenticmail', createSmsWebhookRoutes(db));
+  app.use('/api/agenticmail', createSmsWebhookRoutes(db, config));
 
   // Integration bootstrap routes — mounted BEFORE bearer auth so a fresh
   // AI agent (Claude Code, etc.) can self-install without having to first

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -24,7 +24,7 @@ import { createDomainRoutes } from './routes/domains.js';
 import { createGatewayRoutes } from './routes/gateway.js';
 import { createFeatureRoutes } from './routes/features.js';
 import { createTaskRoutes } from './routes/tasks.js';
-import { createSmsRoutes } from './routes/sms.js';
+import { createSmsRoutes, createSmsWebhookRoutes } from './routes/sms.js';
 import { createStorageRoutes } from './routes/storage.js';
 import { createSystemEventRoutes } from './routes/system-events.js';
 import { createDispatcherActivityRoutes } from './routes/dispatcher-activity.js';
@@ -143,6 +143,7 @@ export function createApp(configOverrides?: Partial<AgenticMailConfig>): {
   });
   app.use(cors());
   app.use(express.json({ limit: '10mb' }));
+  app.use(express.urlencoded({ extended: false, limit: '1mb' }));
   // Cast: express-rate-limit v7 ships Express 5 types; we're on
   // Express 4 types to match the v4 runtime, so the handler signature
   // doesn't line up exactly. The cast is safe because rate-limit's
@@ -211,6 +212,9 @@ export function createApp(configOverrides?: Partial<AgenticMailConfig>): {
 
   // Inbound email webhook (uses its own secret-based auth, before bearer auth)
   app.use('/api/agenticmail', createInboundRoutes(accountManager, config, gatewayManager));
+
+  // Inbound SMS provider webhooks (use provider-specific secrets, before bearer auth)
+  app.use('/api/agenticmail', createSmsWebhookRoutes(db));
 
   // Integration bootstrap routes — mounted BEFORE bearer auth so a fresh
   // AI agent (Claude Code, etc.) can self-install without having to first

--- a/packages/api/src/routes/sms.ts
+++ b/packages/api/src/routes/sms.ts
@@ -33,9 +33,12 @@ function secretMatches(provided: string, expected: string): boolean {
 
 export function createSmsWebhookRoutes(
   db: ReturnType<typeof import('@agenticmail/core').getDatabase>,
+  config: AgenticMailConfig,
 ): Router {
   const router = Router();
-  const smsManager = new SmsManager(db as any);
+  // Pass the master key so the webhook can decrypt the stored
+  // per-agent webhook secret for the timing-safe comparison below.
+  const smsManager = new SmsManager(db as any, config.masterKey);
 
   // POST /sms/webhook/46elks — Receive inbound SMS from 46elks without bearer auth.
   router.post('/sms/webhook/46elks', (req: Request, res: Response) => {
@@ -45,14 +48,18 @@ export function createSmsWebhookRoutes(
         return res.status(400).json({ error: 'Invalid 46elks SMS webhook payload' });
       }
 
+      // Security hardening — an unauthenticated caller must not be able to
+      // tell "no agent owns this number" (404) apart from "wrong secret"
+      // (403): that difference is a phone-number enumeration oracle.
+      // Resolve the agent and verify the secret, then return ONE uniform
+      // 403 for every failure mode (no match / no configured secret /
+      // missing or wrong provided secret). Only a fully valid, secret-
+      // authenticated request gets past this block.
       const match = smsManager.findAgentBySmsNumber(event.to, '46elks');
-      if (!match) {
-        return res.status(404).json({ error: 'No enabled 46elks SMS config found for recipient number' });
-      }
-
-      const expectedSecret = requestString(match.config.webhookSecret);
+      const expectedSecret = match ? requestString(match.config.webhookSecret) : '';
       const providedSecret = readWebhookSecret(req);
-      if (!expectedSecret || !providedSecret || !secretMatches(providedSecret, expectedSecret)) {
+      if (!match || !expectedSecret || !providedSecret
+          || !secretMatches(providedSecret, expectedSecret)) {
         return res.status(403).json({ error: 'Invalid SMS webhook secret' });
       }
 
@@ -87,7 +94,10 @@ export function createSmsRoutes(
   gatewayManager?: any,
 ): Router {
   const router = Router();
-  const smsManager = new SmsManager(db as any);
+  // Master key threads through so SMS provider credentials
+  // (46elks API password, webhook secret, GV forwarding password)
+  // are encrypted at rest in agent metadata, not stored plaintext.
+  const smsManager = new SmsManager(db as any, config.masterKey);
 
   /** Helper: get authenticated agent or return 401 */
   function getAgent(req: Request, res: Response): { id: string; email: string } | null {
@@ -155,6 +165,24 @@ export function createSmsRoutes(
         if (!requestString(webhookSecret)) {
           return res.status(400).json({ error: 'webhookSecret is required for provider "46elks"' });
         }
+        // Security hardening — the outbound SMS call sends the 46elks
+        // Basic-Auth credentials in the request header. If apiUrl were
+        // allowed to be a plaintext-http or arbitrary-scheme URL, those
+        // credentials could be exfiltrated over the wire or pointed at
+        // an internal host (SSRF). Require an https:// URL when an
+        // override is supplied; the built-in default is already https.
+        const apiUrlValue = requestString(apiUrl);
+        if (apiUrlValue) {
+          let parsedApiUrl: URL;
+          try {
+            parsedApiUrl = new URL(apiUrlValue);
+          } catch {
+            return res.status(400).json({ error: 'apiUrl must be a valid URL' });
+          }
+          if (parsedApiUrl.protocol !== 'https:') {
+            return res.status(400).json({ error: 'apiUrl must use https:// — credentials are sent on every request' });
+          }
+        }
 
         const smsConfig: SmsConfig = {
           enabled: true,
@@ -163,7 +191,7 @@ export function createSmsRoutes(
           username: requestString(username),
           password: requestString(password),
           webhookSecret: requestString(webhookSecret),
-          apiUrl: requestString(apiUrl) || undefined,
+          apiUrl: apiUrlValue || undefined,
           configuredAt: new Date().toISOString(),
         };
 
@@ -174,7 +202,8 @@ export function createSmsRoutes(
           sms: redactSmsConfig(smsConfig),
           nextSteps: [
             'Configure the inbound SMS webhook in 46elks for this number.',
-            'Set sms_url to /api/agenticmail/sms/webhook/46elks?secret=<webhookSecret> on this AgenticMail API host.',
+            'Point sms_url at /api/agenticmail/sms/webhook/46elks on this AgenticMail API host.',
+            'Authenticate the webhook by sending the secret in the "x-46elks-secret" request header (preferred — keeps it out of access logs). If your provider can only append query params, ?secret=<webhookSecret> also works.',
             'Outbound SMS will be sent directly through the configured 46elks API credentials.',
           ],
         });

--- a/packages/api/src/routes/sms.ts
+++ b/packages/api/src/routes/sms.ts
@@ -1,14 +1,84 @@
 import { Router, type Request, type Response } from 'express';
+import { timingSafeEqual } from 'node:crypto';
 import {
   SmsManager,
   parseGoogleVoiceSms,
   extractVerificationCode,
   normalizePhoneNumber,
   isValidPhoneNumber,
+  getSmsProvider,
+  mapProviderSmsStatus,
+  redactSmsConfig,
   type AccountManager,
   type AgenticMailConfig,
   type SmsConfig,
 } from '@agenticmail/core';
+
+function requestString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function readWebhookSecret(req: Request): string {
+  return requestString(req.get('x-agenticmail-webhook-secret'))
+    || requestString(req.get('x-46elks-secret'))
+    || requestString(req.query.secret)
+    || requestString((req.body as Record<string, unknown> | undefined)?.secret);
+}
+
+function secretMatches(provided: string, expected: string): boolean {
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+export function createSmsWebhookRoutes(
+  db: ReturnType<typeof import('@agenticmail/core').getDatabase>,
+): Router {
+  const router = Router();
+  const smsManager = new SmsManager(db as any);
+
+  // POST /sms/webhook/46elks — Receive inbound SMS from 46elks without bearer auth.
+  router.post('/sms/webhook/46elks', (req: Request, res: Response) => {
+    try {
+      const event = getSmsProvider('46elks').parseInboundSms(req.body ?? {});
+      if (!event) {
+        return res.status(400).json({ error: 'Invalid 46elks SMS webhook payload' });
+      }
+
+      const match = smsManager.findAgentBySmsNumber(event.to, '46elks');
+      if (!match) {
+        return res.status(404).json({ error: 'No enabled 46elks SMS config found for recipient number' });
+      }
+
+      const expectedSecret = requestString(match.config.webhookSecret);
+      const providedSecret = readWebhookSecret(req);
+      if (!expectedSecret || !providedSecret || !secretMatches(providedSecret, expectedSecret)) {
+        return res.status(403).json({ error: 'Invalid SMS webhook secret' });
+      }
+
+      const sms = smsManager.recordInbound(
+        match.agentId,
+        {
+          from: event.from,
+          body: event.body,
+          timestamp: event.timestamp,
+          raw: JSON.stringify(event.raw ?? event),
+        },
+        {
+          provider: event.provider,
+          providerMessageId: event.id,
+          to: event.to,
+        },
+      );
+
+      res.json({ success: true, sms });
+    } catch (err) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  });
+
+  return router;
+}
 
 export function createSmsRoutes(
   db: ReturnType<typeof import('@agenticmail/core').getDatabase>,
@@ -38,32 +108,77 @@ export function createSmsRoutes(
       const smsConfig = smsManager.getSmsConfig(agent.id);
       res.json({
         configured: !!smsConfig,
-        sms: smsConfig ?? null,
+        sms: smsConfig ? redactSmsConfig(smsConfig) : null,
       });
     } catch (err) {
       res.status(500).json({ error: (err as Error).message });
     }
   });
 
-  // POST /sms/setup — Configure SMS (Google Voice)
+  // POST /sms/setup — Configure SMS provider
   router.post('/sms/setup', (req: Request, res: Response) => {
     try {
       const agent = getAgent(req, res);
       if (!agent) return;
 
-      const { phoneNumber, forwardingEmail, forwardingPassword } = req.body;
+      const {
+        phoneNumber,
+        forwardingEmail,
+        forwardingPassword,
+        provider = 'google_voice',
+        username,
+        password,
+        webhookSecret,
+        apiUrl,
+      } = req.body;
 
       if (!phoneNumber || typeof phoneNumber !== 'string') {
         return res.status(400).json({ error: 'phoneNumber is required (string)' });
       }
 
+      if (provider !== 'google_voice' && provider !== '46elks') {
+        return res.status(400).json({ error: 'provider must be "google_voice" or "46elks"' });
+      }
+
       if (!isValidPhoneNumber(phoneNumber)) {
         return res.status(400).json({
-          error: 'Invalid phone number. Provide a US number like +12125551234 or (212) 555-1234.',
+          error: 'Invalid phone number. Provide an E.164 number like +46701234567 or +12125551234.',
         });
       }
 
       const normalized = normalizePhoneNumber(phoneNumber)!;
+
+      if (provider === '46elks') {
+        if (!requestString(username) || !requestString(password)) {
+          return res.status(400).json({ error: 'username and password are required for provider "46elks"' });
+        }
+        if (!requestString(webhookSecret)) {
+          return res.status(400).json({ error: 'webhookSecret is required for provider "46elks"' });
+        }
+
+        const smsConfig: SmsConfig = {
+          enabled: true,
+          phoneNumber: normalized,
+          provider: '46elks',
+          username: requestString(username),
+          password: requestString(password),
+          webhookSecret: requestString(webhookSecret),
+          apiUrl: requestString(apiUrl) || undefined,
+          configuredAt: new Date().toISOString(),
+        };
+
+        smsManager.saveSmsConfig(agent.id, smsConfig);
+
+        return res.json({
+          success: true,
+          sms: redactSmsConfig(smsConfig),
+          nextSteps: [
+            'Configure the inbound SMS webhook in 46elks for this number.',
+            'Set sms_url to /api/agenticmail/sms/webhook/46elks?secret=<webhookSecret> on this AgenticMail API host.',
+            'Outbound SMS will be sent directly through the configured 46elks API credentials.',
+          ],
+        });
+      }
 
       // Validate forwarding email if provided
       if (forwardingEmail && typeof forwardingEmail === 'string') {
@@ -117,7 +232,7 @@ export function createSmsRoutes(
 
       res.json({
         success: true,
-        sms: { ...smsConfig, forwardingPassword: smsConfig.forwardingPassword ? '***' : undefined },
+        sms: redactSmsConfig(smsConfig),
         nextSteps,
       });
     } catch (err) {
@@ -163,7 +278,7 @@ export function createSmsRoutes(
   });
 
   // POST /sms/send — Record an outbound SMS
-  router.post('/sms/send', (req: Request, res: Response) => {
+  router.post('/sms/send', async (req: Request, res: Response) => {
     try {
       const agent = getAgent(req, res);
       if (!agent) return;
@@ -172,7 +287,7 @@ export function createSmsRoutes(
       if (!smsConfig?.enabled) {
         return res.status(400).json({
           error: 'SMS not configured or disabled. Use sms_setup first.',
-          hint: 'Call agenticmail_sms_setup with your Google Voice phone number.',
+          hint: 'Call agenticmail_sms_setup with provider "46elks" or "google_voice".',
         });
       }
 
@@ -191,7 +306,48 @@ export function createSmsRoutes(
         return res.status(400).json({ error: 'Invalid "to" phone number' });
       }
 
-      const smsRecord = smsManager.recordOutbound(agent.id, to, body, 'pending');
+      if (smsConfig.provider === '46elks') {
+        const smsRecord = smsManager.recordOutbound(agent.id, to, body, 'pending', {
+          provider: smsConfig.provider,
+        });
+
+        try {
+          const result = await getSmsProvider('46elks').sendSms(smsConfig, { to, body });
+          const status = mapProviderSmsStatus(result.status);
+          const metadata = {
+            ...smsRecord.metadata,
+            provider: smsConfig.provider,
+            providerMessageId: result.id,
+          };
+          smsManager.updateStatus(smsRecord.id, status, metadata);
+          return res.json({
+            success: true,
+            sms: { ...smsRecord, status, metadata },
+            providerResult: {
+              provider: result.provider,
+              id: result.id,
+              status: result.status,
+            },
+            delivery: 'direct_provider_api',
+          });
+        } catch (err) {
+          const metadata = {
+            ...smsRecord.metadata,
+            provider: smsConfig.provider,
+            providerError: (err as Error).message,
+          };
+          smsManager.updateStatus(smsRecord.id, 'failed', metadata);
+          return res.status(502).json({
+            success: false,
+            sms: { ...smsRecord, status: 'failed', metadata },
+            error: (err as Error).message,
+          });
+        }
+      }
+
+      const smsRecord = smsManager.recordOutbound(agent.id, to, body, 'pending', {
+        provider: smsConfig.provider,
+      });
 
       res.json({
         success: true,

--- a/packages/core/src/__tests__/sms.test.ts
+++ b/packages/core/src/__tests__/sms.test.ts
@@ -1,10 +1,17 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import {
   normalizePhoneNumber,
   isValidPhoneNumber,
   parseGoogleVoiceSms,
   extractVerificationCode,
+  getSmsProvider,
+  mapProviderSmsStatus,
+  redactSmsConfig,
 } from '../sms/manager.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe('normalizePhoneNumber', () => {
   it('normalizes 10-digit US number', () => {
@@ -17,6 +24,10 @@ describe('normalizePhoneNumber', () => {
 
   it('normalizes +1 prefix', () => {
     expect(normalizePhoneNumber('+12125551234')).toBe('+12125551234');
+  });
+
+  it('keeps international E.164 numbers', () => {
+    expect(normalizePhoneNumber('+46701234567')).toBe('+46701234567');
   });
 
   it('normalizes 11-digit with leading 1', () => {
@@ -35,6 +46,81 @@ describe('normalizePhoneNumber', () => {
 
   it('rejects garbage', () => {
     expect(normalizePhoneNumber('abcdef')).toBeNull();
+  });
+});
+
+describe('SMS providers', () => {
+  it('redacts provider secrets from SMS config', () => {
+    expect(redactSmsConfig({
+      enabled: true,
+      provider: '46elks',
+      phoneNumber: '+46701234567',
+      username: 'u',
+      password: 'p',
+      webhookSecret: 's',
+      configuredAt: '2026-05-18T00:00:00.000Z',
+    })).toMatchObject({
+      provider: '46elks',
+      username: 'u',
+      password: '***',
+      webhookSecret: '***',
+    });
+  });
+
+  it('parses inbound 46elks webhook payloads', () => {
+    const event = getSmsProvider('46elks').parseInboundSms({
+      id: 'sms123',
+      direction: 'incoming',
+      from: '+46709999999',
+      to: '+46701234567',
+      message: 'Your code is 123456',
+      created: '2026-05-18T10:00:00.000Z',
+    });
+
+    expect(event).toMatchObject({
+      provider: '46elks',
+      id: 'sms123',
+      from: '+46709999999',
+      to: '+46701234567',
+      body: 'Your code is 123456',
+    });
+  });
+
+  it('sends 46elks SMS with basic auth and form encoding', async () => {
+    const fetchMock = vi.fn(async (_url: string, _init: RequestInit) => new Response(JSON.stringify({
+      id: 'sms123',
+      status: 'created',
+    }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await getSmsProvider('46elks').sendSms({
+      enabled: true,
+      provider: '46elks',
+      phoneNumber: '+46701234567',
+      username: 'api-user',
+      password: 'api-pass',
+      configuredAt: '2026-05-18T00:00:00.000Z',
+    }, {
+      to: '+46709999999',
+      body: 'Hello',
+    });
+
+    expect(result).toMatchObject({ provider: '46elks', id: 'sms123', status: 'created' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://api.46elks.com/a1/sms');
+    expect(init.method).toBe('POST');
+    expect(init.headers).toMatchObject({
+      Authorization: `Basic ${Buffer.from('api-user:api-pass').toString('base64')}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    });
+    expect(String(init.body)).toBe('to=%2B46709999999&from=%2B46701234567&message=Hello');
+  });
+
+  it('maps provider SMS status to internal status', () => {
+    expect(mapProviderSmsStatus('delivered')).toBe('delivered');
+    expect(mapProviderSmsStatus('created')).toBe('sent');
+    expect(mapProviderSmsStatus('failed')).toBe('failed');
   });
 });
 

--- a/packages/core/src/crypto/secrets.ts
+++ b/packages/core/src/crypto/secrets.ts
@@ -1,0 +1,67 @@
+/**
+ * Symmetric secret encryption for credentials stored at rest in SQLite.
+ *
+ * Extracted from gateway/manager.ts so the same AES-256-GCM scheme can be
+ * reused for any credential the platform persists (relay passwords,
+ * Cloudflare tokens, SMS provider API passwords + webhook secrets, ...).
+ *
+ * Format: "enc2:salt:iv:authTag:ciphertext" — all hex-encoded. The key is
+ * the deployment master key; a per-secret random salt + scrypt KDF means
+ * two identical plaintexts never produce the same ciphertext and a leaked
+ * SQLite file is useless without the master key.
+ */
+import { createCipheriv, createDecipheriv, randomBytes, createHash, scryptSync } from 'node:crypto';
+
+/** Derive a 32-byte AES key from the master key using scrypt + a random salt. */
+function deriveKey(key: string, salt: Buffer): Buffer {
+  return scryptSync(key, salt, 32, { N: 16384, r: 8, p: 1 });
+}
+
+/**
+ * Encrypt a string using AES-256-GCM with a scrypt-derived key.
+ * Returns "enc2:salt:iv:authTag:ciphertext" (all hex-encoded).
+ */
+export function encryptSecret(plaintext: string, key: string): string {
+  const salt = randomBytes(16);
+  const derivedKey = deriveKey(key, salt);
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', derivedKey, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return `enc2:${salt.toString('hex')}:${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted.toString('hex')}`;
+}
+
+/**
+ * Decrypt a string encrypted with {@link encryptSecret}.
+ * Supports the new "enc2:" (scrypt) and legacy "enc:" (SHA-256) formats.
+ * Returns the original plaintext, or the input unchanged if it isn't
+ * recognizably encrypted (tolerates legacy plaintext for migration).
+ */
+export function decryptSecret(value: string, key: string): string {
+  if (value.startsWith('enc2:')) {
+    // New scrypt-based format: enc2:salt:iv:authTag:ciphertext
+    const parts = value.split(':');
+    if (parts.length !== 5) return value;
+    const [, saltHex, ivHex, authTagHex, ciphertextHex] = parts;
+    const derivedKey = deriveKey(key, Buffer.from(saltHex, 'hex'));
+    const decipher = createDecipheriv('aes-256-gcm', derivedKey, Buffer.from(ivHex, 'hex'));
+    decipher.setAuthTag(Buffer.from(authTagHex, 'hex'));
+    return Buffer.concat([decipher.update(Buffer.from(ciphertextHex, 'hex')), decipher.final()]).toString('utf8');
+  }
+  if (value.startsWith('enc:')) {
+    // Legacy SHA-256 format: enc:iv:authTag:ciphertext — read-only for migration
+    const parts = value.split(':');
+    if (parts.length !== 4) return value;
+    const [, ivHex, authTagHex, ciphertextHex] = parts;
+    const keyHash = createHash('sha256').update(key).digest();
+    const decipher = createDecipheriv('aes-256-gcm', keyHash, Buffer.from(ivHex, 'hex'));
+    decipher.setAuthTag(Buffer.from(authTagHex, 'hex'));
+    return Buffer.concat([decipher.update(Buffer.from(ciphertextHex, 'hex')), decipher.final()]).toString('utf8');
+  }
+  return value; // plaintext (unencrypted legacy)
+}
+
+/** True if the value looks like an {@link encryptSecret} output. */
+export function isEncryptedSecret(value: unknown): boolean {
+  return typeof value === 'string' && (value.startsWith('enc2:') || value.startsWith('enc:'));
+}

--- a/packages/core/src/gateway/manager.ts
+++ b/packages/core/src/gateway/manager.ts
@@ -1,6 +1,6 @@
 import type { Database } from '../storage/db.js';
 import { join } from 'node:path';
-import { createCipheriv, createDecipheriv, randomBytes, createHash, scryptSync } from 'node:crypto';
+import { encryptSecret, decryptSecret } from '../crypto/secrets.js';
 import nodemailer from 'nodemailer';
 import { debug } from '../debug.js';
 import { RelayGateway, formatPollError, type InboundEmail } from './relay.js';
@@ -43,57 +43,6 @@ export interface GatewayManagerOptions {
   onInboundMail?: (agentName: string, mail: InboundEmail) => void | Promise<void>;
   /** Master key used to encrypt credentials at rest in SQLite. */
   encryptionKey?: string;
-}
-
-/**
- * Derive a 32-byte AES key from a master key using scrypt (with a random salt).
- * Returns { derivedKey, salt }.
- */
-function deriveKey(key: string, salt: Buffer): Buffer {
-  return scryptSync(key, salt, 32, { N: 16384, r: 8, p: 1 });
-}
-
-/**
- * Encrypt a string using AES-256-GCM with scrypt-derived key.
- * Returns "enc2:salt:iv:authTag:ciphertext" (all hex-encoded).
- */
-function encryptSecret(plaintext: string, key: string): string {
-  const salt = randomBytes(16);
-  const derivedKey = deriveKey(key, salt);
-  const iv = randomBytes(12);
-  const cipher = createCipheriv('aes-256-gcm', derivedKey, iv);
-  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
-  const authTag = cipher.getAuthTag();
-  return `enc2:${salt.toString('hex')}:${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted.toString('hex')}`;
-}
-
-/**
- * Decrypt a string encrypted with encryptSecret.
- * Supports both new "enc2:" (scrypt) and legacy "enc:" (SHA-256) formats.
- * Returns the original plaintext, or the input unchanged if not encrypted.
- */
-function decryptSecret(value: string, key: string): string {
-  if (value.startsWith('enc2:')) {
-    // New scrypt-based format: enc2:salt:iv:authTag:ciphertext
-    const parts = value.split(':');
-    if (parts.length !== 5) return value;
-    const [, saltHex, ivHex, authTagHex, ciphertextHex] = parts;
-    const derivedKey = deriveKey(key, Buffer.from(saltHex, 'hex'));
-    const decipher = createDecipheriv('aes-256-gcm', derivedKey, Buffer.from(ivHex, 'hex'));
-    decipher.setAuthTag(Buffer.from(authTagHex, 'hex'));
-    return Buffer.concat([decipher.update(Buffer.from(ciphertextHex, 'hex')), decipher.final()]).toString('utf8');
-  }
-  if (value.startsWith('enc:')) {
-    // Legacy SHA-256 format: enc:iv:authTag:ciphertext — read-only for migration
-    const parts = value.split(':');
-    if (parts.length !== 4) return value;
-    const [, ivHex, authTagHex, ciphertextHex] = parts;
-    const keyHash = createHash('sha256').update(key).digest();
-    const decipher = createDecipheriv('aes-256-gcm', keyHash, Buffer.from(ivHex, 'hex'));
-    decipher.setAuthTag(Buffer.from(authTagHex, 'hex'));
-    return Buffer.concat([decipher.update(Buffer.from(ciphertextHex, 'hex')), decipher.final()]).toString('utf8');
-  }
-  return value; // plaintext (unencrypted legacy)
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -84,8 +84,26 @@ export type {
 export { RELAY_PRESETS } from './gateway/types.js';
 
 // SMS / Google Voice
-export { SmsManager, SmsPoller, parseGoogleVoiceSms, extractVerificationCode, normalizePhoneNumber, isValidPhoneNumber } from './sms/index.js';
-export type { SmsConfig, ParsedSms, SmsMessage } from './sms/index.js';
+export {
+  SmsManager,
+  SmsPoller,
+  parseGoogleVoiceSms,
+  extractVerificationCode,
+  normalizePhoneNumber,
+  isValidPhoneNumber,
+  getSmsProvider,
+  mapProviderSmsStatus,
+  redactSmsConfig,
+} from './sms/index.js';
+export type {
+  SmsConfig,
+  ParsedSms,
+  SmsMessage,
+  SendSmsInput,
+  SendSmsResult,
+  InboundSmsEvent,
+  SmsProvider,
+} from './sms/index.js';
 
 // Telemetry
 export { recordToolCall, setTelemetryVersion, flushTelemetry } from './telemetry.js';

--- a/packages/core/src/sms/index.ts
+++ b/packages/core/src/sms/index.ts
@@ -1,2 +1,20 @@
-export { SmsManager, SmsPoller, parseGoogleVoiceSms, extractVerificationCode, normalizePhoneNumber, isValidPhoneNumber } from './manager.js';
-export type { SmsConfig, ParsedSms, SmsMessage } from './manager.js';
+export {
+  SmsManager,
+  SmsPoller,
+  parseGoogleVoiceSms,
+  extractVerificationCode,
+  normalizePhoneNumber,
+  isValidPhoneNumber,
+  getSmsProvider,
+  mapProviderSmsStatus,
+  redactSmsConfig,
+} from './manager.js';
+export type {
+  SmsConfig,
+  ParsedSms,
+  SmsMessage,
+  SendSmsInput,
+  SendSmsResult,
+  InboundSmsEvent,
+  SmsProvider,
+} from './manager.js';

--- a/packages/core/src/sms/manager.ts
+++ b/packages/core/src/sms/manager.ts
@@ -11,6 +11,7 @@
  */
 
 import type { Database } from '../storage/db.js';
+import { encryptSecret, decryptSecret, isEncryptedSecret } from '../crypto/secrets.js';
 
 export interface SmsConfig {
   /** Whether SMS is enabled for this agent */
@@ -92,7 +93,15 @@ function asString(value: unknown): string {
 }
 
 function defaultApiUrl(config: SmsConfig): string {
-  return (config.apiUrl || 'https://api.46elks.com/a1').replace(/\/+$/, '');
+  const url = (config.apiUrl || 'https://api.46elks.com/a1').replace(/\/+$/, '');
+  // Defense-in-depth — the outbound call attaches Basic-Auth credentials,
+  // so the endpoint MUST be https. The /sms/setup route already rejects
+  // non-https overrides, but enforce it again at the point of use in case
+  // a config was persisted before that validation existed.
+  if (!/^https:\/\//i.test(url)) {
+    throw new Error('46elks apiUrl must use https:// — refusing to send credentials over a non-TLS connection');
+  }
+  return url;
 }
 
 function basicAuth(username: string, password: string): string {
@@ -418,11 +427,59 @@ export function extractVerificationCode(smsBody: string): string | null {
   return null;
 }
 
+/**
+ * Credential fields on SmsConfig that must never sit in plaintext at rest.
+ * The 46elks API password, the inbound-webhook shared secret, and the
+ * Google Voice forwarding-mailbox app password are all live credentials —
+ * a leaked SQLite file should not hand an attacker a working account.
+ */
+const SMS_SECRET_FIELDS = ['password', 'webhookSecret', 'forwardingPassword'] as const;
+
 export class SmsManager {
   private initialized = false;
 
-  constructor(private db: Database) {
+  /**
+   * Optional master key used to encrypt SMS credentials at rest (same
+   * AES-256-GCM scheme GatewayManager uses for relay/domain secrets).
+   * When absent (e.g. tests, or a deployment with no master key) configs
+   * are stored as-is and reads tolerate plaintext — so upgrades and
+   * downgrades both stay safe.
+   */
+  constructor(private db: Database, private encryptionKey?: string) {
     this.ensureTable();
+  }
+
+  /** Encrypt the credential fields of an SMS config before persisting. */
+  private encryptConfig(config: SmsConfig): SmsConfig {
+    if (!this.encryptionKey) return config;
+    const out: SmsConfig = { ...config };
+    for (const field of SMS_SECRET_FIELDS) {
+      const value = out[field];
+      // Only encrypt non-empty plaintext — never double-encrypt.
+      if (typeof value === 'string' && value && !isEncryptedSecret(value)) {
+        out[field] = encryptSecret(value, this.encryptionKey);
+      }
+    }
+    return out;
+  }
+
+  /** Decrypt the credential fields of an SMS config after loading. */
+  private decryptConfig(config: SmsConfig): SmsConfig {
+    if (!this.encryptionKey) return config;
+    const out: SmsConfig = { ...config };
+    for (const field of SMS_SECRET_FIELDS) {
+      const value = out[field];
+      if (typeof value === 'string' && isEncryptedSecret(value)) {
+        try {
+          out[field] = decryptSecret(value, this.encryptionKey);
+        } catch {
+          // Wrong key / corrupt blob — leave the ciphertext in place
+          // rather than crashing; the caller's auth check will simply
+          // fail closed.
+        }
+      }
+    }
+    return out;
   }
 
   private ensureTable(): void {
@@ -451,19 +508,20 @@ export class SmsManager {
     }
   }
 
-  /** Get SMS config from agent metadata */
+  /** Get SMS config from agent metadata (credential fields decrypted). */
   getSmsConfig(agentId: string): SmsConfig | null {
     const row = this.db.prepare('SELECT metadata FROM agents WHERE id = ?').get(agentId) as { metadata: string } | undefined;
     if (!row) return null;
     try {
       const meta = JSON.parse(row.metadata || '{}');
-      return meta.sms && meta.sms.enabled !== undefined ? meta.sms : null;
+      if (!meta.sms || meta.sms.enabled === undefined) return null;
+      return this.decryptConfig(meta.sms as SmsConfig);
     } catch {
       return null;
     }
   }
 
-  /** Save SMS config to agent metadata */
+  /** Save SMS config to agent metadata (credential fields encrypted). */
   saveSmsConfig(agentId: string, config: SmsConfig): void {
     const row = this.db.prepare('SELECT metadata FROM agents WHERE id = ?').get(agentId) as { metadata: string } | undefined;
     if (!row) throw new Error(`Agent ${agentId} not found`);
@@ -474,7 +532,7 @@ export class SmsManager {
     } catch {
       meta = {};
     }
-    meta.sms = config;
+    meta.sms = this.encryptConfig(config);
     this.db.prepare("UPDATE agents SET metadata = ?, updated_at = datetime('now') WHERE id = ?")
       .run(JSON.stringify(meta), agentId);
   }
@@ -531,7 +589,9 @@ export class SmsManager {
         if (!cfg?.enabled) continue;
         if (provider && cfg.provider !== provider) continue;
         if (normalizePhoneNumber(cfg.phoneNumber) === normalized) {
-          return { agentId: row.id, config: cfg };
+          // Decrypt before returning so callers (e.g. the webhook secret
+          // check) compare against the real plaintext, not ciphertext.
+          return { agentId: row.id, config: this.decryptConfig(cfg) };
         }
       } catch {
         // Ignore malformed agent metadata.

--- a/packages/core/src/sms/manager.ts
+++ b/packages/core/src/sms/manager.ts
@@ -1,11 +1,11 @@
 /**
- * SMS Manager - Google Voice SMS integration
+ * SMS Manager - provider-backed SMS integration
  *
  * How it works:
- * 1. User sets up Google Voice with SMS-to-email forwarding
- * 2. Incoming SMS arrives at Google Voice -> forwarded to email -> lands in agent inbox
- * 3. Agent parses forwarded SMS from email body
- * 4. Outgoing SMS sent via Google Voice web interface (browser automation)
+ * 1. User chooses a provider for the agent phone number
+ * 2. Google Voice uses email forwarding/web instructions
+ * 3. 46elks uses direct API sends and inbound webhooks
+ * 4. All inbound/outbound messages are stored in the SMS table
  *
  * SMS config is stored in agent metadata under the "sms" key.
  */
@@ -15,16 +15,24 @@ import type { Database } from '../storage/db.js';
 export interface SmsConfig {
   /** Whether SMS is enabled for this agent */
   enabled: boolean;
-  /** Google Voice phone number (e.g. +12125551234) */
+  /** Phone number in E.164 format where possible */
   phoneNumber: string;
   /** The email address Google Voice forwards SMS to (the Gmail used for GV signup) */
-  forwardingEmail: string;
+  forwardingEmail?: string;
   /** App password for forwarding email (only needed if different from relay email) */
   forwardingPassword?: string;
   /** Whether the GV Gmail is the same as the relay email */
   sameAsRelay?: boolean;
-  /** Provider (currently only google_voice) */
-  provider: 'google_voice';
+  /** SMS provider */
+  provider: 'google_voice' | '46elks';
+  /** 46elks API username */
+  username?: string;
+  /** 46elks API password */
+  password?: string;
+  /** Provider API base URL override */
+  apiUrl?: string;
+  /** Secret required on inbound provider webhooks */
+  webhookSecret?: string;
   /** When SMS was configured */
   configuredAt: string;
 }
@@ -45,6 +53,184 @@ export interface SmsMessage {
   status: 'pending' | 'sent' | 'delivered' | 'failed' | 'received';
   createdAt: string;
   metadata?: Record<string, unknown>;
+}
+
+export interface SendSmsInput {
+  to: string;
+  body: string;
+  dryRun?: boolean;
+}
+
+export interface SendSmsResult {
+  provider: SmsConfig['provider'];
+  id?: string;
+  status: string;
+  from: string;
+  to: string;
+  body: string;
+  raw?: unknown;
+}
+
+export interface InboundSmsEvent {
+  provider: SmsConfig['provider'];
+  id?: string;
+  from: string;
+  to: string;
+  body: string;
+  timestamp: string;
+  raw?: unknown;
+}
+
+export interface SmsProvider {
+  id: SmsConfig['provider'];
+  sendSms(config: SmsConfig, input: SendSmsInput): Promise<SendSmsResult>;
+  parseInboundSms(payload: Record<string, unknown>): InboundSmsEvent | null;
+}
+
+function asString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function defaultApiUrl(config: SmsConfig): string {
+  return (config.apiUrl || 'https://api.46elks.com/a1').replace(/\/+$/, '');
+}
+
+function basicAuth(username: string, password: string): string {
+  return Buffer.from(`${username}:${password}`, 'utf8').toString('base64');
+}
+
+export function redactSmsConfig(config: SmsConfig): SmsConfig {
+  return {
+    ...config,
+    forwardingPassword: config.forwardingPassword ? '***' : undefined,
+    password: config.password ? '***' : undefined,
+    webhookSecret: config.webhookSecret ? '***' : undefined,
+  };
+}
+
+class GoogleVoiceSmsProvider implements SmsProvider {
+  id = 'google_voice' as const;
+
+  async sendSms(config: SmsConfig, input: SendSmsInput): Promise<SendSmsResult> {
+    const to = normalizePhoneNumber(input.to);
+    const from = normalizePhoneNumber(config.phoneNumber);
+    if (!to) throw new Error('Invalid recipient phone number');
+    if (!from) throw new Error('Invalid configured Google Voice phone number');
+
+    return {
+      provider: this.id,
+      status: 'pending',
+      from,
+      to,
+      body: input.body,
+      raw: {
+        delivery: 'manual_google_voice_web',
+        url: 'https://voice.google.com',
+      },
+    };
+  }
+
+  parseInboundSms(): InboundSmsEvent | null {
+    return null;
+  }
+}
+
+class FortySixElksSmsProvider implements SmsProvider {
+  id = '46elks' as const;
+
+  async sendSms(config: SmsConfig, input: SendSmsInput): Promise<SendSmsResult> {
+    const username = asString(config.username);
+    const password = asString(config.password);
+    if (!username || !password) {
+      throw new Error('46elks username and password are required');
+    }
+
+    const to = normalizePhoneNumber(input.to);
+    const from = normalizePhoneNumber(config.phoneNumber);
+    if (!to) throw new Error('Invalid recipient phone number');
+    if (!from) throw new Error('Invalid configured 46elks phone number');
+
+    const form = new URLSearchParams();
+    form.set('to', to);
+    form.set('from', from);
+    form.set('message', input.body);
+    if (input.dryRun) form.set('dryrun', 'yes');
+
+    const response = await fetch(`${defaultApiUrl(config)}/sms`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Basic ${basicAuth(username, password)}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: form,
+      signal: AbortSignal.timeout(15_000),
+    });
+
+    const text = await response.text();
+    let raw: unknown = text;
+    try {
+      raw = JSON.parse(text);
+    } catch {
+      // Keep raw provider response as text.
+    }
+
+    if (!response.ok) {
+      const message = typeof raw === 'object' && raw && ('message' in raw || 'error' in raw)
+        ? String((raw as { message?: unknown; error?: unknown }).message ?? (raw as { error?: unknown }).error)
+        : text.slice(0, 200);
+      throw new Error(`46elks SMS failed (${response.status}): ${message}`);
+    }
+
+    const providerId = typeof raw === 'object' && raw && 'id' in raw ? String((raw as { id?: unknown }).id) : undefined;
+    const providerStatus = typeof raw === 'object' && raw && 'status' in raw ? String((raw as { status?: unknown }).status) : 'sent';
+
+    return {
+      provider: this.id,
+      id: providerId,
+      status: providerStatus,
+      from,
+      to,
+      body: input.body,
+      raw,
+    };
+  }
+
+  parseInboundSms(payload: Record<string, unknown>): InboundSmsEvent | null {
+    const direction = asString(payload.direction).toLowerCase();
+    if (direction && direction !== 'incoming') return null;
+
+    const from = normalizePhoneNumber(asString(payload.from));
+    const to = normalizePhoneNumber(asString(payload.to));
+    const body = asString(payload.message);
+    if (!from || !to || !body) return null;
+
+    return {
+      provider: this.id,
+      id: asString(payload.id) || undefined,
+      from,
+      to,
+      body,
+      timestamp: asString(payload.created) || new Date().toISOString(),
+      raw: payload,
+    };
+  }
+}
+
+const PROVIDERS: Record<SmsConfig['provider'], SmsProvider> = {
+  google_voice: new GoogleVoiceSmsProvider(),
+  '46elks': new FortySixElksSmsProvider(),
+};
+
+export function getSmsProvider(provider: SmsConfig['provider']): SmsProvider {
+  return PROVIDERS[provider];
+}
+
+export function mapProviderSmsStatus(status: string): SmsMessage['status'] {
+  const normalized = status.toLowerCase();
+  if (normalized === 'delivered') return 'delivered';
+  if (normalized === 'failed' || normalized === 'error') return 'failed';
+  if (normalized === 'created' || normalized === 'queued' || normalized === 'sent') return 'sent';
+  return 'sent';
 }
 
 /** Normalize a phone number to E.164-ish format (+1XXXXXXXXXX) */
@@ -332,20 +518,43 @@ export class SmsManager {
       .run(JSON.stringify(meta), agentId);
   }
 
-  /** Record an inbound SMS (parsed from email) */
-  recordInbound(agentId: string, parsed: ParsedSms): SmsMessage {
+  /** Find the agent whose SMS config owns a phone number. */
+  findAgentBySmsNumber(phoneNumber: string, provider?: SmsConfig['provider']): { agentId: string; config: SmsConfig } | null {
+    const normalized = normalizePhoneNumber(phoneNumber);
+    if (!normalized) return null;
+
+    const rows = this.db.prepare('SELECT id, metadata FROM agents').all() as { id: string; metadata: string }[];
+    for (const row of rows) {
+      try {
+        const meta = JSON.parse(row.metadata || '{}');
+        const cfg = meta.sms as SmsConfig | undefined;
+        if (!cfg?.enabled) continue;
+        if (provider && cfg.provider !== provider) continue;
+        if (normalizePhoneNumber(cfg.phoneNumber) === normalized) {
+          return { agentId: row.id, config: cfg };
+        }
+      } catch {
+        // Ignore malformed agent metadata.
+      }
+    }
+
+    return null;
+  }
+
+  /** Record an inbound SMS (parsed from email or provider webhook) */
+  recordInbound(agentId: string, parsed: ParsedSms, metadata?: Record<string, unknown>): SmsMessage {
     const id = `sms_in_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
     const createdAt = parsed.timestamp || new Date().toISOString();
 
     this.db.prepare(
-      'INSERT INTO sms_messages (id, agent_id, direction, phone_number, body, status, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)'
-    ).run(id, agentId, 'inbound', parsed.from, parsed.body, 'received', createdAt);
+      'INSERT INTO sms_messages (id, agent_id, direction, phone_number, body, status, created_at, metadata) VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
+    ).run(id, agentId, 'inbound', parsed.from, parsed.body, 'received', createdAt, JSON.stringify(metadata ?? {}));
 
-    return { id, agentId, direction: 'inbound', phoneNumber: parsed.from, body: parsed.body, status: 'received', createdAt };
+    return { id, agentId, direction: 'inbound', phoneNumber: parsed.from, body: parsed.body, status: 'received', createdAt, metadata };
   }
 
   /** Record an outbound SMS attempt */
-  recordOutbound(agentId: string, phoneNumber: string, body: string, status: 'pending' | 'sent' | 'failed' = 'pending'): SmsMessage {
+  recordOutbound(agentId: string, phoneNumber: string, body: string, status: 'pending' | 'sent' | 'failed' = 'pending', metadata?: Record<string, unknown>): SmsMessage {
     const id = `sms_out_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
     const now = new Date().toISOString();
 
@@ -353,14 +562,20 @@ export class SmsManager {
     const normalized = normalizePhoneNumber(phoneNumber) || phoneNumber;
 
     this.db.prepare(
-      'INSERT INTO sms_messages (id, agent_id, direction, phone_number, body, status, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)'
-    ).run(id, agentId, 'outbound', normalized, body, status, now);
+      'INSERT INTO sms_messages (id, agent_id, direction, phone_number, body, status, created_at, metadata) VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
+    ).run(id, agentId, 'outbound', normalized, body, status, now, JSON.stringify(metadata ?? {}));
 
-    return { id, agentId, direction: 'outbound', phoneNumber: normalized, body, status, createdAt: now };
+    return { id, agentId, direction: 'outbound', phoneNumber: normalized, body, status, createdAt: now, metadata };
   }
 
-  /** Update SMS status */
-  updateStatus(id: string, status: SmsMessage['status']): void {
+  /** Update SMS status and optional provider metadata */
+  updateStatus(id: string, status: SmsMessage['status'], metadata?: Record<string, unknown>): void {
+    if (metadata) {
+      this.db.prepare('UPDATE sms_messages SET status = ?, metadata = ? WHERE id = ?')
+        .run(status, JSON.stringify(metadata), id);
+      return;
+    }
+
     this.db.prepare('UPDATE sms_messages SET status = ? WHERE id = ?').run(status, id);
   }
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -243,8 +243,8 @@ These tools require the master key:
 
 | Tool | Description |
 |------|-------------|
-| `sms_setup` | Configure Google Voice phone number for SMS access |
-| `sms_send` | Record and send SMS via Google Voice |
+| `sms_setup` | Configure Google Voice or 46elks phone number access |
+| `sms_send` | Send SMS through 46elks API or return Google Voice send instructions |
 | `sms_messages` | List inbound/outbound SMS messages |
 | `sms_check_code` | Extract verification/OTP codes from recent SMS |
 | `sms_read_voice` | Read SMS directly from Google Voice web (fastest method) |

--- a/packages/mcp/REFERENCE.md
+++ b/packages/mcp/REFERENCE.md
@@ -109,10 +109,10 @@ Search for available domains via Cloudflare Registrar (requires master API key).
 ## SMS / Phone
 
 ### `sms_setup`
-Configure SMS/phone number access via Google Voice. The user must have a Google Voice account with SMS-to-email forwarding enabled.
+Configure SMS/phone number access via Google Voice legacy forwarding or 46elks direct API/webhooks.
 
 ### `sms_send`
-Send an SMS text message via Google Voice. Records the message and provides instructions for sending via Google Voice web interface.
+Send an SMS text message. 46elks configs send directly through the provider API; Google Voice configs record the message and return browser-send instructions.
 
 ### `sms_messages`
 List SMS messages (inbound and outbound). Use direction filter to see only received or sent messages..
@@ -136,4 +136,3 @@ Get the current SMS/phone number configuration for this agent. Shows whether SMS
 
 ### `storage`
 Full database management system for agents. 28 actions: DDL (create/alter/drop/clone/rename tables & columns), DML (insert/upsert/query/aggregate/update/delete/truncate), indexing (create/list/drop/reindex), import/export (JSON/CSV, conflict handling), raw SQL, maintenance (stats/vacuum/analyze/explain), archiving.
-

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -1037,22 +1037,28 @@ export const toolDefinitions = [
     },
   },
 
-  // --- SMS / Google Voice Tools ---
+  // --- SMS / Phone Tools ---
   {
     name: 'sms_setup',
-    description: 'Configure SMS/phone number access via Google Voice. The user must have a Google Voice account with SMS-to-email forwarding enabled. This gives the agent a phone number for receiving verification codes and sending texts.',
+    description: 'Configure SMS/phone number access. Supports Google Voice legacy forwarding and direct 46elks provider delivery/webhooks.',
     inputSchema: {
       type: 'object' as const,
       properties: {
-        phoneNumber: { type: 'string', description: 'Google Voice phone number (e.g. +12125551234)' },
-        forwardingEmail: { type: 'string', description: 'Email address Google Voice forwards SMS to (defaults to agent email)' },
+        phoneNumber: { type: 'string', description: 'SMS phone number in E.164 format (e.g. +46701234567 or +12125551234)' },
+        provider: { type: 'string', enum: ['google_voice', '46elks'], description: 'SMS provider (default: google_voice)' },
+        forwardingEmail: { type: 'string', description: 'Google Voice only: email address Google Voice forwards SMS to (defaults to agent email)' },
+        forwardingPassword: { type: 'string', description: 'Google Voice only: app password for a separate forwarding Gmail' },
+        username: { type: 'string', description: '46elks only: API username' },
+        password: { type: 'string', description: '46elks only: API password' },
+        webhookSecret: { type: 'string', description: '46elks only: shared secret required on inbound SMS webhooks' },
+        apiUrl: { type: 'string', description: '46elks only: optional API base URL override' },
       },
       required: ['phoneNumber'],
     },
   },
   {
     name: 'sms_send',
-    description: 'Send an SMS text message via Google Voice. Records the message and provides instructions for sending via Google Voice web interface. The agent can automate the actual send using browser automation on voice.google.com.',
+    description: 'Send an SMS text message. Direct provider configs such as 46elks send through the provider API; Google Voice legacy configs return browser-send instructions.',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -2804,13 +2810,18 @@ async function dispatchToolCall(name: string, args: Record<string, unknown>, use
       throw new Error('Invalid action. Use: list or get');
     }
 
-    // --- SMS / Google Voice Tools ---
+    // --- SMS / Phone Tools ---
 
     case 'sms_setup': {
       const result = await apiRequest('POST', '/sms/setup', {
         phoneNumber: args.phoneNumber,
+        provider: args.provider ?? 'google_voice',
         forwardingEmail: args.forwardingEmail,
-        provider: 'google_voice',
+        forwardingPassword: args.forwardingPassword,
+        username: args.username,
+        password: args.password,
+        webhookSecret: args.webhookSecret,
+        apiUrl: args.apiUrl,
       });
       return JSON.stringify(result, null, 2);
     }

--- a/packages/openclaw/README.md
+++ b/packages/openclaw/README.md
@@ -287,8 +287,8 @@ Self-messaging is also prevented — an agent cannot send a message to itself.
 
 | Tool | Description |
 |------|-------------|
-| `agenticmail_sms_setup` | Configure Google Voice phone number for SMS access |
-| `agenticmail_sms_send` | Record and send SMS via Google Voice |
+| `agenticmail_sms_setup` | Configure Google Voice or 46elks phone number access |
+| `agenticmail_sms_send` | Send SMS through 46elks API or return Google Voice send instructions |
 | `agenticmail_sms_messages` | List inbound/outbound SMS messages |
 | `agenticmail_sms_check_code` | Extract verification/OTP codes from recent SMS |
 | `agenticmail_sms_read_voice` | Read SMS directly from Google Voice web (fastest method) |

--- a/packages/openclaw/REFERENCE.md
+++ b/packages/openclaw/REFERENCE.md
@@ -187,10 +187,10 @@ Search for available domains via Cloudflare Registrar (requires master key). NOT
 ## SMS / Phone
 
 ### `agenticmail_sms_setup`
-Configure SMS/phone number access via Google Voice. The user must have a Google Voice account with SMS-to-email forwarding enabled.
+Configure SMS/phone number access via Google Voice legacy forwarding or 46elks direct API/webhooks.
 
 ### `agenticmail_sms_send`
-Send an SMS text message via Google Voice. Records the message and provides instructions for sending via Google Voice web interface.
+Send an SMS text message. 46elks configs send directly through the provider API; Google Voice configs record the message and return browser-send instructions.
 
 ### `agenticmail_sms_messages`
 List SMS messages (inbound and outbound). Use direction filter to see only received or sent messages..
@@ -208,10 +208,9 @@ Record an SMS message that you read from Google Voice web or any other source. S
 Parse an SMS from a forwarded Google Voice email. Use this when you receive an email from Google Voice containing an SMS.
 
 ### `agenticmail_sms_config`
-Get the current SMS/phone number configuration for this agent. Shows whether SMS is enabled, the phone number, and forwarding email..
+Get the current SMS/phone number configuration for this agent. Secrets are redacted.
 
 ## Database Storage
 
 ### `agenticmail_storage`
 Full database management for agents. Create/alter/drop tables, CRUD rows, manage indexes, run aggregations, import/export data, execute raw SQL, optimize & analyze — all on whatever database the user deployed (SQLite, Postgres, MySQL, Turso).
-

--- a/packages/openclaw/skill/SKILL.md
+++ b/packages/openclaw/skill/SKILL.md
@@ -116,8 +116,8 @@ That's it. The command sets up the mail server, creates an agent account, config
 ### SMS / Phone (8 tools)
 | Tool | Description |
 |------|-------------|
-| `agenticmail_sms_setup` | Configure SMS via Google Voice (phone number + forwarding email) |
-| `agenticmail_sms_send` | Send an SMS text message via Google Voice |
+| `agenticmail_sms_setup` | Configure SMS via Google Voice or 46elks |
+| `agenticmail_sms_send` | Send SMS via direct provider API or Google Voice instructions |
 | `agenticmail_sms_messages` | List SMS messages (inbound/outbound) |
 | `agenticmail_sms_check_code` | Check for recent verification/OTP codes from SMS |
 | `agenticmail_sms_read_voice` | Read SMS directly from Google Voice web (fastest method) |
@@ -238,7 +238,7 @@ Set in your OpenClaw config under `plugins.entries`:
 - **Automatic follow-up** — Exponential backoff reminders when blocked emails await approval
 - **Spam filtering** — Inbound emails scored and flagged with configurable thresholds
 - **Task delegation** — Inter-agent task queue with assign, claim, submit, and synchronous RPC
-- **SMS / Phone** — Google Voice integration for verification codes and text messaging
+- **SMS / Phone** — Google Voice or 46elks integration for verification codes and text messaging
 - **Database storage** — 28-action DBMS (DDL, DML, indexing, aggregation, import/export, raw SQL)
 - **Rate limiting** — Built-in protection against agent email storms
 - **Configurable inbox awareness** — Agents can receive unread count, summaries, or required read-first prompts

--- a/packages/openclaw/src/tools.ts
+++ b/packages/openclaw/src/tools.ts
@@ -2163,28 +2163,39 @@ export function registerTools(
     },
   });
 
-  // --- SMS / Google Voice Tools ---
+  // --- SMS / Phone Tools ---
 
   reg('agenticmail_sms_setup', {
-    description: 'Configure SMS/phone number access via Google Voice. The user must have a Google Voice account with SMS-to-email forwarding enabled. This gives the agent a phone number for receiving verification codes and sending texts.',
+    description: 'Configure SMS/phone number access. Supports Google Voice legacy forwarding and direct 46elks provider delivery/webhooks. This gives the agent a phone number for receiving verification codes and sending texts.',
     parameters: {
-      phoneNumber: { type: 'string', required: true, description: 'Google Voice phone number (e.g. +12125551234)' },
-      forwardingEmail: { type: 'string', description: 'Email address Google Voice forwards SMS to (defaults to agent email)' },
+      phoneNumber: { type: 'string', required: true, description: 'SMS phone number in E.164 format (e.g. +46701234567 or +12125551234)' },
+      provider: { type: 'string', description: 'SMS provider: "google_voice" (default) or "46elks"' },
+      forwardingEmail: { type: 'string', description: 'Google Voice only: email address Google Voice forwards SMS to (defaults to agent email)' },
+      forwardingPassword: { type: 'string', description: 'Google Voice only: app password for a separate forwarding Gmail' },
+      username: { type: 'string', description: '46elks only: API username' },
+      password: { type: 'string', description: '46elks only: API password' },
+      webhookSecret: { type: 'string', description: '46elks only: shared secret required on inbound SMS webhooks' },
+      apiUrl: { type: 'string', description: '46elks only: optional API base URL override' },
     },
     handler: async (params: any) => {
       try {
         const c = await ctxForParams(ctx, params);
         return await apiRequest(c, 'POST', '/sms/setup', {
           phoneNumber: params.phoneNumber,
+          provider: params.provider ?? 'google_voice',
           forwardingEmail: params.forwardingEmail,
-          provider: 'google_voice',
+          forwardingPassword: params.forwardingPassword,
+          username: params.username,
+          password: params.password,
+          webhookSecret: params.webhookSecret,
+          apiUrl: params.apiUrl,
         });
       } catch (err) { return { success: false, error: (err as Error).message }; }
     },
   });
 
   reg('agenticmail_sms_send', {
-    description: 'Send an SMS text message via Google Voice. Records the message and provides instructions for sending via Google Voice web interface. The agent can automate the actual send using the browser tool on voice.google.com.',
+    description: 'Send an SMS text message. Direct provider configs such as 46elks send through the provider API; Google Voice legacy configs record the message and return browser-send instructions for voice.google.com.',
     parameters: {
       to: { type: 'string', required: true, description: 'Recipient phone number' },
       body: { type: 'string', required: true, description: 'Text message body' },
@@ -2456,7 +2467,7 @@ WHERE filters support operators: {column: value} for equality, {column: {$gt: 5,
   });
 
   reg('agenticmail_sms_config', {
-    description: 'Get the current SMS/phone number configuration for this agent. Shows whether SMS is enabled, the phone number, and forwarding email.',
+    description: 'Get the current SMS/phone number configuration for this agent. Secrets are redacted.',
     parameters: {},
     handler: async (params: any) => {
       try {


### PR DESCRIPTION
## Summary
- add a provider-backed SMS registry while keeping Google Voice as the default legacy provider
- add 46elks direct outbound SMS support using Basic Auth and form-encoded API calls
- add a secret-protected inbound 46elks webhook mounted before bearer auth
- expose provider selection through REST, MCP, and OpenClaw SMS setup tools
- redact provider credentials in config responses and update docs

## Verification
- npm test --workspace=@agenticmail/core
- npm run build --workspace=@agenticmail/core
- npm run build --workspace=@agenticmail/api
- npm run build --workspace=@agenticmail/mcp
- npm run build --workspace=@agenticmail/openclaw
- npm test --workspace=@agenticmail/api
- npm test --workspace=@agenticmail/mcp
- npm test --workspace=@agenticmail/openclaw
- git diff --check

## Provider notes
- 46elks API integration follows the official API base/auth/form-encoded SMS docs.
- Inbound SMS is handled via a provider webhook secret; no AgenticMail bearer key is expected from the provider.