### PR TITLE
feat(core): share bridge wake primitives

### DIFF
--- a/packages/claudecode/src/bridge-wake.ts
+++ b/packages/claudecode/src/bridge-wake.ts
@@ -41,6 +41,11 @@
  * Tests live in `__tests__/bridge-wake.test.ts` with the SDK stubbed.
  */
 
+import {
+  bridgeWakeErrorMessage,
+  classifyResumeError,
+  type BridgeWakeResult,
+} from '@agenticmail/core';
 import type { AgenticMailAccount } from './types.js';
 import type { QueryFn } from './dispatcher.js';
 
@@ -58,17 +63,6 @@ export interface BridgeWakeInput {
   mcpEnv: Record<string, string>;
   /** Wall-clock cap for the headless turn. */
   timeoutMs?: number;
-}
-
-export interface BridgeWakeResult {
-  ok: boolean;
-  /** Captured assistant text (for logs / system-event preview). */
-  text?: string;
-  /** Error class — drives fallback routing. */
-  error?: 'session-expired' | 'sdk-missing' | 'timeout' | 'other';
-  errorMessage?: string;
-  /** Duration in ms — surfaces in dispatcher activity. */
-  durationMs?: number;
 }
 
 /**
@@ -146,63 +140,9 @@ export async function resumeBridgeSession(
     log('info', `[bridge-wake] resumed session ok (${result.durationMs}ms, ${assistantText.length} chars)`);
     return result;
   } catch (err) {
-    const msg = (err as Error)?.message ?? String(err);
-    // Heuristic error-class detection — both Anthropic and the CLI
-    // surface "session not found" / "invalid session" / "session
-    // expired" phrasing for an evicted session. Any of those means
-    // "give up, forget the record, escalate via SMS".
-    const m = msg.toLowerCase();
-    const expired = m.includes('session not found')
-      || m.includes('invalid session')
-      || m.includes('session expired')
-      || m.includes('no such session')
-      || m.includes('unknown session');
-    const sdkMissing = m.includes('cannot find module')
-      || m.includes("could not be found")
-      || m.includes('command not found');
-    const error: BridgeWakeResult['error'] = expired
-      ? 'session-expired'
-      : sdkMissing
-        ? 'sdk-missing'
-        : 'other';
+    const msg = bridgeWakeErrorMessage(err);
+    const error = classifyResumeError(err);
     log('warn', `[bridge-wake] resume failed (${error}): ${msg.slice(0, 200)}`);
     return { ok: false, error, errorMessage: msg, durationMs: Date.now() - startMs };
   }
-}
-
-/**
- * Build the prompt the resumed session sees on wake. The bridge
- * mail's metadata is interpolated into a short context block so
- * the resumed session can decide what to do without re-reading the
- * full thread.
- */
-export function composeBridgeWakePrompt(args: {
-  bridgeName: string;
-  uid: number;
-  subject?: string;
-  from?: string;
-  preview?: string;
-}): string {
-  const subject = args.subject ?? '(no subject)';
-  const from = args.from ?? 'unknown';
-  const preview = (args.preview ?? '').slice(0, 600);
-  return [
-    `🎀 Bridge mail arrived — headless wake.`,
-    '',
-    `You are being resumed against your last session because new mail landed in your bridge inbox (${args.bridgeName}@localhost) and you weren't actively at the keyboard.`,
-    '',
-    `Trigger:`,
-    `  UID:     ${args.uid}`,
-    `  From:    ${from}`,
-    `  Subject: ${subject}`,
-    `  Preview: ${preview}`,
-    '',
-    `Read it with mcp__agenticmail__read_email({ uid: ${args.uid} }) and decide:`,
-    `  · Does it need a reply from YOU (the operator's session)? Reply via mcp__agenticmail__reply_email.`,
-    `  · Does it need a teammate to act? Forward / re-route by replying with wake: ["<teammate>"].`,
-    `  · Is it [NEEDS OPERATOR] / [BLOCKED]? Then it's actually for the human — mark it unread, and the operator will see it on their next keystroke.`,
-    `  · Is it FYI noise? mark_read and exit.`,
-    '',
-    `Keep this turn SHORT. You're being resumed to handle ONE piece of mail, not to continue the prior conversation.`,
-  ].join('\n');
 }

--- a/packages/claudecode/src/dispatcher.ts
+++ b/packages/claudecode/src/dispatcher.ts
@@ -46,8 +46,18 @@ import { DispatcherState } from './dispatcher-state.js';
 import { mkdirSync, createWriteStream, rmSync, type WriteStream } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
-import { ThreadCache, AgentMemoryStore, threadIdFor, normalizeSubject, loadHostSession, forgetHostSession } from '@agenticmail/core';
-import { resumeBridgeSession, composeBridgeWakePrompt } from './bridge-wake.js';
+import {
+  ThreadCache,
+  AgentMemoryStore,
+  bridgeWakeLastSeenAgeMs,
+  composeBridgeWakePrompt,
+  forgetHostSession,
+  loadHostSession,
+  normalizeSubject,
+  shouldSkipBridgeWakeForLiveOperator,
+  threadIdFor,
+} from '@agenticmail/core';
+import { resumeBridgeSession } from './bridge-wake.js';
 
 /** Event shape we accept off the SSE stream. */
 interface SSEEvent {
@@ -1939,8 +1949,10 @@ export class Dispatcher {
       ?? '';
     try {
       const saved = loadHostSession('claudecode');
-      if (saved && Date.now() - saved.lastSeenMs < 30_000) {
-        this.log('info', `[bridge-wake] skip — operator is live (lastSeen=${Date.now() - saved.lastSeenMs}ms ago); their hook will surface uid=${event.uid}`);
+      const nowMs = Date.now();
+      if (shouldSkipBridgeWakeForLiveOperator(saved, nowMs)) {
+        const ageMs = bridgeWakeLastSeenAgeMs(saved, nowMs) ?? 0;
+        this.log('info', `[bridge-wake] skip — operator is live (lastSeen=${ageMs}ms ago); their hook will surface uid=${event.uid}`);
         this.postActivity('/dispatcher/bridge-skipped', {
           uid: event.uid, agentName: account.name, reason: 'operator-live',
         });

--- a/packages/codex/src/bridge-wake.ts
+++ b/packages/codex/src/bridge-wake.ts
@@ -15,6 +15,11 @@
  * picks up where the operator left off.
  */
 
+import {
+  bridgeWakeErrorMessage,
+  classifyResumeError,
+  type BridgeWakeResult,
+} from '@agenticmail/core';
 import type { AgenticMailAccount } from './types.js';
 
 export interface BridgeWakeInput {
@@ -28,14 +33,6 @@ export interface BridgeWakeInput {
   sandboxMode?: 'workspace-write' | 'read-only' | 'danger-full-access';
   approvalPolicy?: 'never' | 'on-request' | 'untrusted';
   timeoutMs?: number;
-}
-
-export interface BridgeWakeResult {
-  ok: boolean;
-  text?: string;
-  error?: 'session-expired' | 'sdk-missing' | 'timeout' | 'other';
-  errorMessage?: string;
-  durationMs?: number;
 }
 
 /**
@@ -56,7 +53,7 @@ export async function resumeBridgeThread(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     sdk = await import('@openai/codex-sdk' as any) as typeof import('@openai/codex-sdk');
   } catch (err) {
-    const msg = (err as Error)?.message ?? String(err);
+    const msg = bridgeWakeErrorMessage(err);
     log('warn', `[bridge-wake] @openai/codex-sdk not available: ${msg.slice(0, 200)}`);
     return { ok: false, error: 'sdk-missing', errorMessage: msg, durationMs: Date.now() - startMs };
   }
@@ -122,50 +119,9 @@ export async function resumeBridgeThread(
     log('info', `[bridge-wake] resumed thread ok (${result.durationMs}ms, ${assistantText.length} chars)`);
     return result;
   } catch (err) {
-    const msg = (err as Error)?.message ?? String(err);
-    const m = msg.toLowerCase();
-    const expired = m.includes('thread not found')
-      || m.includes('invalid thread')
-      || m.includes('thread expired')
-      || m.includes('no such thread')
-      || m.includes('unknown thread')
-      || m.includes('session not found');
-    const error: BridgeWakeResult['error'] = expired ? 'session-expired' : 'other';
+    const msg = bridgeWakeErrorMessage(err);
+    const error = classifyResumeError(err, { sdkMissingMarkers: [] });
     log('warn', `[bridge-wake] resume failed (${error}): ${msg.slice(0, 200)}`);
     return { ok: false, error, errorMessage: msg, durationMs: Date.now() - startMs };
   }
-}
-
-/** Same prompt composer as the Claude Code variant — shape-identical
- *  so a future @agenticmail/host-toolkit refactor can pull this into
- *  a single shared implementation. */
-export function composeBridgeWakePrompt(args: {
-  bridgeName: string;
-  uid: number;
-  subject?: string;
-  from?: string;
-  preview?: string;
-}): string {
-  const subject = args.subject ?? '(no subject)';
-  const from = args.from ?? 'unknown';
-  const preview = (args.preview ?? '').slice(0, 600);
-  return [
-    `🎀 Bridge mail arrived — headless wake.`,
-    '',
-    `You are being resumed against your last session because new mail landed in your bridge inbox (${args.bridgeName}@localhost) and you weren't actively at the keyboard.`,
-    '',
-    `Trigger:`,
-    `  UID:     ${args.uid}`,
-    `  From:    ${from}`,
-    `  Subject: ${subject}`,
-    `  Preview: ${preview}`,
-    '',
-    `Read it with mcp__agenticmail__read_email({ uid: ${args.uid} }) and decide:`,
-    `  · Does it need a reply from YOU (the operator's session)? Reply via mcp__agenticmail__reply_email.`,
-    `  · Does it need a teammate to act? Forward / re-route by replying with wake: ["<teammate>"].`,
-    `  · Is it [NEEDS OPERATOR] / [BLOCKED]? Then it's actually for the human — mark it unread, and the operator will see it on their next keystroke.`,
-    `  · Is it FYI noise? mark_read and exit.`,
-    '',
-    `Keep this turn SHORT. You're being resumed to handle ONE piece of mail, not to continue the prior conversation.`,
-  ].join('\n');
 }

--- a/packages/codex/src/dispatcher.ts
+++ b/packages/codex/src/dispatcher.ts
@@ -51,8 +51,18 @@ import { DispatcherState } from './dispatcher-state.js';
 import { mkdirSync, createWriteStream, rmSync, type WriteStream } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
-import { ThreadCache, AgentMemoryStore, threadIdFor, normalizeSubject, loadHostSession, forgetHostSession } from '@agenticmail/core';
-import { resumeBridgeThread, composeBridgeWakePrompt } from './bridge-wake.js';
+import {
+  ThreadCache,
+  AgentMemoryStore,
+  bridgeWakeLastSeenAgeMs,
+  composeBridgeWakePrompt,
+  forgetHostSession,
+  loadHostSession,
+  normalizeSubject,
+  shouldSkipBridgeWakeForLiveOperator,
+  threadIdFor,
+} from '@agenticmail/core';
+import { resumeBridgeThread } from './bridge-wake.js';
 
 /** Event shape we accept off the SSE stream. */
 interface SSEEvent {
@@ -2159,8 +2169,10 @@ export class Dispatcher {
       ?? '';
     try {
       const saved = loadHostSession('codex');
-      if (saved && Date.now() - saved.lastSeenMs < 30_000) {
-        this.log('info', `[bridge-wake] skip — operator is live (lastSeen=${Date.now() - saved.lastSeenMs}ms ago); their hook will surface uid=${event.uid}`);
+      const nowMs = Date.now();
+      if (shouldSkipBridgeWakeForLiveOperator(saved, nowMs)) {
+        const ageMs = bridgeWakeLastSeenAgeMs(saved, nowMs) ?? 0;
+        this.log('info', `[bridge-wake] skip — operator is live (lastSeen=${ageMs}ms ago); their hook will surface uid=${event.uid}`);
         this.postActivity('/dispatcher/bridge-skipped', {
           uid: event.uid, agentName: account.name, reason: 'operator-live',
         });

--- a/packages/core/src/__tests__/host-bridge.test.ts
+++ b/packages/core/src/__tests__/host-bridge.test.ts
@@ -1,0 +1,69 @@
+import {
+  BRIDGE_OPERATOR_LIVE_WINDOW_MS,
+  bridgeWakeErrorMessage,
+  bridgeWakeLastSeenAgeMs,
+  classifyResumeError,
+  composeBridgeWakePrompt,
+  shouldSkipBridgeWakeForLiveOperator,
+} from '../host-bridge.js';
+
+describe('host-bridge', () => {
+  it('composes a stable bridge wake prompt', () => {
+    const prompt = composeBridgeWakePrompt({
+      bridgeName: 'openclaw',
+      uid: 42,
+      from: 'sender@example.com',
+      subject: 'Need a call',
+      preview: 'Please check this reservation request.',
+    });
+
+    expect(prompt).toContain('Bridge mail arrived');
+    expect(prompt).toContain('openclaw@localhost');
+    expect(prompt).toContain('UID:     42');
+    expect(prompt).toContain('From:    sender@example.com');
+    expect(prompt).toContain('Subject: Need a call');
+    expect(prompt).toContain('mcp__agenticmail__read_email({ uid: 42 })');
+    expect(prompt).toContain('Keep this turn SHORT');
+  });
+
+  it('uses safe defaults and truncates long previews', () => {
+    const prompt = composeBridgeWakePrompt({
+      bridgeName: 'codex',
+      uid: 7,
+      preview: 'x'.repeat(700),
+    });
+
+    expect(prompt).toContain('From:    unknown');
+    expect(prompt).toContain('Subject: (no subject)');
+    expect(prompt).toContain(`Preview: ${'x'.repeat(600)}`);
+    expect(prompt).not.toContain('x'.repeat(601));
+  });
+
+  it('classifies expired session and thread errors', () => {
+    expect(classifyResumeError(new Error('session not found'))).toBe('session-expired');
+    expect(classifyResumeError(new Error('thread expired'))).toBe('session-expired');
+    expect(classifyResumeError(new Error('Cannot find module @openai/codex-sdk'))).toBe('sdk-missing');
+    expect(classifyResumeError(new Error('rate limit'))).toBe('other');
+  });
+
+  it('can keep sdk-missing classification host-specific', () => {
+    const error = new Error('command not found');
+    expect(classifyResumeError(error)).toBe('sdk-missing');
+    expect(classifyResumeError(error, { sdkMissingMarkers: [] })).toBe('other');
+  });
+
+  it('normalizes unknown error messages', () => {
+    expect(bridgeWakeErrorMessage('plain failure')).toBe('plain failure');
+  });
+
+  it('detects live operators with a shared window', () => {
+    const nowMs = 1_000_000;
+    const live = { lastSeenMs: nowMs - BRIDGE_OPERATOR_LIVE_WINDOW_MS + 1 };
+    const stale = { lastSeenMs: nowMs - BRIDGE_OPERATOR_LIVE_WINDOW_MS };
+
+    expect(bridgeWakeLastSeenAgeMs(live, nowMs)).toBe(29_999);
+    expect(shouldSkipBridgeWakeForLiveOperator(live, nowMs)).toBe(true);
+    expect(shouldSkipBridgeWakeForLiveOperator(stale, nowMs)).toBe(false);
+    expect(shouldSkipBridgeWakeForLiveOperator(null, nowMs)).toBe(false);
+  });
+});

--- a/packages/core/src/host-bridge.ts
+++ b/packages/core/src/host-bridge.ts
@@ -1,0 +1,109 @@
+import type { HostSession } from './host-sessions.js';
+
+export type BridgeWakeError = 'session-expired' | 'sdk-missing' | 'timeout' | 'other';
+
+export interface BridgeWakeResult {
+  ok: boolean;
+  text?: string;
+  error?: BridgeWakeError;
+  errorMessage?: string;
+  durationMs?: number;
+}
+
+export interface BridgeWakePromptArgs {
+  bridgeName: string;
+  uid: number;
+  subject?: string;
+  from?: string;
+  preview?: string;
+}
+
+export interface ResumeErrorClassificationOptions {
+  expiredMarkers?: readonly string[];
+  sdkMissingMarkers?: readonly string[];
+}
+
+export const BRIDGE_OPERATOR_LIVE_WINDOW_MS = 30_000;
+
+const DEFAULT_EXPIRED_MARKERS = [
+  'session not found',
+  'invalid session',
+  'session expired',
+  'no such session',
+  'unknown session',
+  'thread not found',
+  'invalid thread',
+  'thread expired',
+  'no such thread',
+  'unknown thread',
+] as const;
+
+const DEFAULT_SDK_MISSING_MARKERS = [
+  'cannot find module',
+  'could not be found',
+  'command not found',
+] as const;
+
+export function bridgeWakeErrorMessage(err: unknown): string {
+  return (err as Error)?.message ?? String(err);
+}
+
+export function classifyResumeError(
+  err: unknown,
+  options: ResumeErrorClassificationOptions = {},
+): BridgeWakeError {
+  const msg = bridgeWakeErrorMessage(err).toLowerCase();
+  const expiredMarkers = options.expiredMarkers ?? DEFAULT_EXPIRED_MARKERS;
+  const sdkMissingMarkers = options.sdkMissingMarkers ?? DEFAULT_SDK_MISSING_MARKERS;
+  if (expiredMarkers.some((marker) => msg.includes(marker))) return 'session-expired';
+  if (sdkMissingMarkers.some((marker) => msg.includes(marker))) return 'sdk-missing';
+  return 'other';
+}
+
+export function bridgeWakeLastSeenAgeMs(
+  session: Pick<HostSession, 'lastSeenMs'> | null | undefined,
+  nowMs = Date.now(),
+): number | null {
+  if (!session) return null;
+  return nowMs - session.lastSeenMs;
+}
+
+export function shouldSkipBridgeWakeForLiveOperator(
+  session: Pick<HostSession, 'lastSeenMs'> | null | undefined,
+  nowMs = Date.now(),
+  liveWindowMs = BRIDGE_OPERATOR_LIVE_WINDOW_MS,
+): boolean {
+  const ageMs = bridgeWakeLastSeenAgeMs(session, nowMs);
+  return ageMs !== null && ageMs < liveWindowMs;
+}
+
+/**
+ * Build the prompt a host session sees on bridge wake. Host adapters
+ * keep their own SDK resume call, but share this operator-facing
+ * instruction shape so Claude Code, Codex, OpenClaw and later hosts
+ * do not drift semantically.
+ */
+export function composeBridgeWakePrompt(args: BridgeWakePromptArgs): string {
+  const subject = args.subject ?? '(no subject)';
+  const from = args.from ?? 'unknown';
+  const preview = (args.preview ?? '').slice(0, 600);
+  return [
+    `🎀 Bridge mail arrived — headless wake.`,
+    '',
+    `You are being resumed against your last session because new mail landed in your bridge inbox (${args.bridgeName}@localhost) and you weren't actively at the keyboard.`,
+    '',
+    `Trigger:`,
+    `  UID:     ${args.uid}`,
+    `  From:    ${from}`,
+    `  Subject: ${subject}`,
+    `  Preview: ${preview}`,
+    '',
+    `Read it with mcp__agenticmail__read_email({ uid: ${args.uid} }) and decide:`,
+    `  · Does it need a reply from YOU (the operator's session)? Reply via mcp__agenticmail__reply_email.`,
+    `  · Does it need a teammate to act? Forward / re-route by replying with wake: ["<teammate>"].`,
+    `  · Is it [NEEDS OPERATOR] / [BLOCKED]? Then it's actually for the human — mark it unread, and the operator will see it on their next keystroke.`,
+    `  · Is it FYI noise? mark_read and exit.`,
+    '',
+    `Keep this turn SHORT. You're being resumed to handle ONE piece of mail, not to continue the prior conversation.`,
+  ].join('\n');
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -160,6 +160,19 @@ export {
   type HostSession,
 } from './host-sessions.js';
 
+export {
+  BRIDGE_OPERATOR_LIVE_WINDOW_MS,
+  bridgeWakeErrorMessage,
+  bridgeWakeLastSeenAgeMs,
+  classifyResumeError,
+  composeBridgeWakePrompt,
+  shouldSkipBridgeWakeForLiveOperator,
+  type BridgeWakeError,
+  type BridgeWakePromptArgs,
+  type BridgeWakeResult,
+  type ResumeErrorClassificationOptions,
+} from './host-bridge.js';
+
 // SSRF-safe URL validation for the master API base URL — used by
 // every host integration to bound where its fetch requests can go.
 // See util/safe-url.ts for the blocklist (cloud metadata, file://,


### PR DESCRIPTION
## Summary

- Add shared bridge wake primitives to `@agenticmail/core`.
- Move bridge wake prompt composition, resume error classification, and live-operator skip logic behind Core helpers.
- Keep Claude Code and Codex SDK resume calls host-specific.

## Scope

- Adds `packages/core/src/host-bridge.ts`.
- Adds focused host bridge tests.
- Updates Claude Code and Codex bridge/dispatcher code to use shared Core primitives.
- Does not add OpenClaw runtime integration, phone mission state, or a dispatcher rewrite.

## Tests

```bash
npm test --workspace=@agenticmail/core -- --run src/__tests__/host-bridge.test.ts
npm test --workspace=@agenticmail/core -- --run src/__tests__/host-sessions.test.ts src/__tests__/host-bridge.test.ts
npm test --workspace=@agenticmail/core
npm run build --workspace=@agenticmail/core
npm run build --workspace=@agenticmail/claudecode
npm run build --workspace=@agenticmail/codex
npm test --workspace=@agenticmail/claudecode
npm test --workspace=@agenticmail/codex
git diff --check
```