### PR TITLE
feat(core): add bridge routing helper

### DIFF
--- a/packages/claudecode/src/dispatcher.ts
+++ b/packages/claudecode/src/dispatcher.ts
@@ -49,12 +49,10 @@ import { homedir } from 'node:os';
 import {
   ThreadCache,
   AgentMemoryStore,
-  bridgeWakeLastSeenAgeMs,
-  composeBridgeWakePrompt,
   forgetHostSession,
   loadHostSession,
   normalizeSubject,
-  shouldSkipBridgeWakeForLiveOperator,
+  planBridgeWake,
   threadIdFor,
 } from '@agenticmail/core';
 import { resumeBridgeSession } from './bridge-wake.js';
@@ -1949,32 +1947,31 @@ export class Dispatcher {
       ?? '';
     try {
       const saved = loadHostSession('claudecode');
-      const nowMs = Date.now();
-      if (shouldSkipBridgeWakeForLiveOperator(saved, nowMs)) {
-        const ageMs = bridgeWakeLastSeenAgeMs(saved, nowMs) ?? 0;
-        this.log('info', `[bridge-wake] skip — operator is live (lastSeen=${ageMs}ms ago); their hook will surface uid=${event.uid}`);
+      const route = planBridgeWake({
+        session: saved,
+        mail: { bridgeName: account.name, uid: event.uid, subject, from, preview },
+      });
+      if (route.action === 'skip-live') {
+        this.log('info', `[bridge-wake] skip — operator is live (lastSeen=${route.ageMs}ms ago); their hook will surface uid=${event.uid}`);
         this.postActivity('/dispatcher/bridge-skipped', {
-          uid: event.uid, agentName: account.name, reason: 'operator-live',
+          uid: event.uid, agentName: account.name, reason: route.reason,
         });
         return;
       }
-      if (!saved) {
+      if (route.action === 'escalate') {
         this.log('warn', `[bridge-wake] no fresh Claude Code session recorded — bridge mail uid=${event.uid} cannot resume. Escalating via system-event.`);
         this.postActivity('/dispatcher/bridge-escalation', {
           uid: event.uid, agentName: account.name, subject, from, preview,
-          reason: 'no-fresh-session',
+          reason: route.reason,
         });
         return;
       }
       const mcpEnv = await this.buildMcpEnv();
-      const prompt = composeBridgeWakePrompt({
-        bridgeName: account.name, uid: event.uid, subject, from, preview,
-      });
       const result = await resumeBridgeSession(this.query, {
         bridge: account,
-        sessionId: saved.sessionId,
-        cwd: saved.workspace,
-        prompt,
+        sessionId: route.session.sessionId,
+        cwd: route.session.workspace,
+        prompt: route.prompt,
         mcpEnv,
       }, this.log);
       if (result.ok) {

--- a/packages/codex/src/dispatcher.ts
+++ b/packages/codex/src/dispatcher.ts
@@ -54,12 +54,10 @@ import { homedir } from 'node:os';
 import {
   ThreadCache,
   AgentMemoryStore,
-  bridgeWakeLastSeenAgeMs,
-  composeBridgeWakePrompt,
   forgetHostSession,
   loadHostSession,
   normalizeSubject,
-  shouldSkipBridgeWakeForLiveOperator,
+  planBridgeWake,
   threadIdFor,
 } from '@agenticmail/core';
 import { resumeBridgeThread } from './bridge-wake.js';
@@ -2169,31 +2167,30 @@ export class Dispatcher {
       ?? '';
     try {
       const saved = loadHostSession('codex');
-      const nowMs = Date.now();
-      if (shouldSkipBridgeWakeForLiveOperator(saved, nowMs)) {
-        const ageMs = bridgeWakeLastSeenAgeMs(saved, nowMs) ?? 0;
-        this.log('info', `[bridge-wake] skip — operator is live (lastSeen=${ageMs}ms ago); their hook will surface uid=${event.uid}`);
+      const route = planBridgeWake({
+        session: saved,
+        mail: { bridgeName: account.name, uid: event.uid, subject, from, preview },
+      });
+      if (route.action === 'skip-live') {
+        this.log('info', `[bridge-wake] skip — operator is live (lastSeen=${route.ageMs}ms ago); their hook will surface uid=${event.uid}`);
         this.postActivity('/dispatcher/bridge-skipped', {
-          uid: event.uid, agentName: account.name, reason: 'operator-live',
+          uid: event.uid, agentName: account.name, reason: route.reason,
         });
         return;
       }
-      if (!saved) {
+      if (route.action === 'escalate') {
         this.log('warn', `[bridge-wake] no fresh Codex thread recorded — bridge mail uid=${event.uid} cannot resume. Escalating via system-event.`);
         this.postActivity('/dispatcher/bridge-escalation', {
           uid: event.uid, agentName: account.name, subject, from, preview,
-          reason: 'no-fresh-session',
+          reason: route.reason,
         });
         return;
       }
-      const prompt = composeBridgeWakePrompt({
-        bridgeName: account.name, uid: event.uid, subject, from, preview,
-      });
       const result = await resumeBridgeThread({
         bridge: account,
-        sessionId: saved.sessionId,
-        cwd: saved.workspace,
-        prompt,
+        sessionId: route.session.sessionId,
+        cwd: route.session.workspace,
+        prompt: route.prompt,
         sandboxMode: 'workspace-write',
         approvalPolicy: 'never',
       }, this.log);

--- a/packages/core/src/__tests__/host-bridge.test.ts
+++ b/packages/core/src/__tests__/host-bridge.test.ts
@@ -4,6 +4,7 @@ import {
   bridgeWakeLastSeenAgeMs,
   classifyResumeError,
   composeBridgeWakePrompt,
+  planBridgeWake,
   shouldSkipBridgeWakeForLiveOperator,
 } from '../host-bridge.js';
 
@@ -65,5 +66,45 @@ describe('host-bridge', () => {
     expect(shouldSkipBridgeWakeForLiveOperator(live, nowMs)).toBe(true);
     expect(shouldSkipBridgeWakeForLiveOperator(stale, nowMs)).toBe(false);
     expect(shouldSkipBridgeWakeForLiveOperator(null, nowMs)).toBe(false);
+  });
+
+  it('plans bridge wake routing decisions', () => {
+    const nowMs = 1_000_000;
+    const mail = {
+      bridgeName: 'claudecode',
+      uid: 123,
+      subject: 'Bridge request',
+      from: 'teammate@example.com',
+      preview: 'Please handle this.',
+    };
+
+    expect(planBridgeWake({
+      session: { sessionId: 'live', lastSeenMs: nowMs - 1_000 },
+      mail,
+      nowMs,
+    })).toMatchObject({
+      action: 'skip-live',
+      reason: 'operator-live',
+      ageMs: 1_000,
+      mail,
+    });
+
+    expect(planBridgeWake({ session: null, mail, nowMs })).toMatchObject({
+      action: 'escalate',
+      reason: 'no-fresh-session',
+      mail,
+    });
+
+    const resume = planBridgeWake({
+      session: { sessionId: 'stale-enough', workspace: '/tmp/project', lastSeenMs: nowMs - 60_000 },
+      mail,
+      nowMs,
+    });
+    expect(resume).toMatchObject({
+      action: 'resume',
+      session: { sessionId: 'stale-enough', workspace: '/tmp/project' },
+      mail,
+    });
+    expect(resume.action === 'resume' ? resume.prompt : '').toContain('Bridge request');
   });
 });

--- a/packages/core/src/host-bridge.ts
+++ b/packages/core/src/host-bridge.ts
@@ -18,6 +18,34 @@ export interface BridgeWakePromptArgs {
   preview?: string;
 }
 
+export interface BridgeMailContext extends BridgeWakePromptArgs {}
+
+export type BridgeWakeRoute =
+  | {
+      action: 'skip-live';
+      reason: 'operator-live';
+      ageMs: number;
+      mail: BridgeMailContext;
+    }
+  | {
+      action: 'escalate';
+      reason: 'no-fresh-session';
+      mail: BridgeMailContext;
+    }
+  | {
+      action: 'resume';
+      session: HostSession;
+      prompt: string;
+      mail: BridgeMailContext;
+    };
+
+export interface PlanBridgeWakeArgs {
+  session: HostSession | null;
+  mail: BridgeMailContext;
+  nowMs?: number;
+  liveWindowMs?: number;
+}
+
 export interface ResumeErrorClassificationOptions {
   expiredMarkers?: readonly string[];
   sdkMissingMarkers?: readonly string[];
@@ -75,6 +103,33 @@ export function shouldSkipBridgeWakeForLiveOperator(
 ): boolean {
   const ageMs = bridgeWakeLastSeenAgeMs(session, nowMs);
   return ageMs !== null && ageMs < liveWindowMs;
+}
+
+export function planBridgeWake(args: PlanBridgeWakeArgs): BridgeWakeRoute {
+  const nowMs = args.nowMs ?? Date.now();
+  const liveWindowMs = args.liveWindowMs ?? BRIDGE_OPERATOR_LIVE_WINDOW_MS;
+  const ageMs = bridgeWakeLastSeenAgeMs(args.session, nowMs);
+  if (ageMs !== null && ageMs < liveWindowMs) {
+    return {
+      action: 'skip-live',
+      reason: 'operator-live',
+      ageMs,
+      mail: args.mail,
+    };
+  }
+  if (!args.session) {
+    return {
+      action: 'escalate',
+      reason: 'no-fresh-session',
+      mail: args.mail,
+    };
+  }
+  return {
+    action: 'resume',
+    session: args.session,
+    prompt: composeBridgeWakePrompt(args.mail),
+    mail: args.mail,
+  };
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -167,10 +167,14 @@ export {
   bridgeWakeLastSeenAgeMs,
   classifyResumeError,
   composeBridgeWakePrompt,
+  planBridgeWake,
   shouldSkipBridgeWakeForLiveOperator,
   type BridgeWakeError,
+  type BridgeMailContext,
   type BridgeWakePromptArgs,
   type BridgeWakeResult,
+  type BridgeWakeRoute,
+  type PlanBridgeWakeArgs,
   type ResumeErrorClassificationOptions,
 } from './host-bridge.js';
 


### PR DESCRIPTION
## Summary

- Add `planBridgeWake()` to `@agenticmail/core` so hosts share the bridge-mail routing decision.
- Route Claude Code and Codex bridge mail through the shared helper while keeping their SDK resume calls host-specific.
- Preserve current skip/resume/escalation behavior and event payloads.

## Base note

PR #37 has merged. This branch was rebased on current `main`; the remaining commit in this PR is `3f4565f`.

## Scope

- `packages/core/src/host-bridge.ts`
- `packages/core/src/__tests__/host-bridge.test.ts`
- `packages/core/src/index.ts`
- `packages/claudecode/src/dispatcher.ts`
- `packages/codex/src/dispatcher.ts`

## Tests

```bash
npm test --workspace=@agenticmail/core -- --run src/__tests__/host-bridge.test.ts
npm test --workspace=@agenticmail/core
npm run build --workspace=@agenticmail/core
npm test --workspace=@agenticmail/claudecode
npm test --workspace=@agenticmail/codex
npm run build --workspace=@agenticmail/claudecode
npm run build --workspace=@agenticmail/codex
git diff --check
```