### PR TITLE
Capture OpenClaw host sessions as wake-only

### DIFF
--- a/packages/openclaw/index.ts
+++ b/packages/openclaw/index.ts
@@ -2,6 +2,7 @@ import { registerTools, recordInboundAgentMessage, registerAgentIdentity, unregi
 import { initFollowUpSystem, cancelAllFollowUps } from './src/pending-followup.js';
 import { mailChannelPlugin } from './src/channel.js';
 import { createMailMonitorService } from './src/monitor.js';
+import { recordOpenClawHostSession } from './src/host-session.js';
 import {
   formatUnreadInboxContext,
   resolveInboxInjectionConfig,
@@ -206,7 +207,7 @@ function stopSubAgentWatcher(agentName: string): void {
 
 /** Check if a session key belongs to a sub-agent (format: agent:*:subagent:*) */
 function isSubagentSession(sessionKey: string): boolean {
-  return sessionKey.includes(':subagent:');
+  return sessionKey.startsWith('subagent:') || sessionKey.includes(':subagent:');
 }
 
 /** Sanitize a label into a valid agent email name (lowercase alphanumeric + dashes) */
@@ -610,6 +611,8 @@ function activate(api: any): void {
   // send intro emails, start SSE watchers. No prompt mutation here —
   // that's handled by before_prompt_build below.
   api.on('before_agent_start', async (_event: any, context: any) => {
+    recordOpenClawHostSession(context, 'before_agent_start');
+
     const sessionKey: string = context?.sessionKey ?? '';
     const isSubAgent = isSubagentSession(sessionKey);
 
@@ -783,6 +786,8 @@ function activate(api: any): void {
   // from before_agent_start). Uses prependSystemContext for static guidance
   // (cacheable across turns) and prependContext for dynamic per-turn content.
   api.on('before_prompt_build', async (_event: any, context: any) => {
+    recordOpenClawHostSession(context, 'before_prompt_build');
+
     const sessionKey: string = context?.sessionKey ?? '';
     let agentApiKey = ctx.config.apiKey;
     const prependLines: string[] = [];
@@ -1002,6 +1007,8 @@ function activate(api: any): void {
   // tool params when the hook has session context. The main injection path is
   // the tool factory in registerTools() which always has the session key.
   api.on('before_tool_call', async (event: any, context: any) => {
+    recordOpenClawHostSession(context, 'before_tool_call');
+
     const toolName: string = event?.toolName ?? '';
 
     // --- Sub-agent API key injection (fallback for when factory didn't inject) ---

--- a/packages/openclaw/src/__tests__/host-session.test.ts
+++ b/packages/openclaw/src/__tests__/host-session.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildOpenClawHostSession,
+  isOpenClawHostSessionKey,
+  isOpenClawMailChannelSessionKey,
+  isOpenClawSubagentSessionKey,
+} from '../host-session.js';
+
+describe('OpenClaw host session capture', () => {
+  it('identifies host session keys without treating sub-agents or mail channels as operators', () => {
+    expect(isOpenClawHostSessionKey('agent:main')).toBe(true);
+    expect(isOpenClawHostSessionKey('agent:main:subagent:abc')).toBe(false);
+    expect(isOpenClawHostSessionKey('subagent:agenticmail-task-1')).toBe(false);
+    expect(isOpenClawHostSessionKey('mail:thread:<message-id>')).toBe(false);
+    expect(isOpenClawHostSessionKey('')).toBe(false);
+  });
+
+  it('keeps the narrower key predicates available for hook routing', () => {
+    expect(isOpenClawSubagentSessionKey('agent:main:subagent:abc')).toBe(true);
+    expect(isOpenClawSubagentSessionKey('subagent:agenticmail-task-1')).toBe(true);
+    expect(isOpenClawMailChannelSessionKey('mail:sender@example.com')).toBe(true);
+    expect(isOpenClawMailChannelSessionKey('agent:main')).toBe(false);
+  });
+
+  it('builds wake-only host sessions from OpenClaw hook context', () => {
+    const session = buildOpenClawHostSession({
+      sessionKey: 'agent:main',
+      cwd: '/work/project',
+      model: 'anthropic/claude-sonnet-4',
+      agentId: 'main',
+      agentName: 'operator',
+      channel: 'terminal',
+    }, 'before_prompt_build');
+
+    expect(session).toEqual({
+      sessionId: 'agent:main',
+      workspace: '/work/project',
+      model: 'anthropic/claude-sonnet-4',
+      resumeMode: 'wake-only',
+      hostMetadata: {
+        sessionKey: 'agent:main',
+        surface: 'before_prompt_build',
+        agentId: 'main',
+        agentName: 'operator',
+        channel: 'terminal',
+      },
+    });
+  });
+
+  it('falls back to the current workspace when OpenClaw omits cwd data', () => {
+    const session = buildOpenClawHostSession(
+      { sessionKey: 'agent:main' },
+      'before_tool_call',
+      '/fallback/workspace',
+    );
+
+    expect(session?.workspace).toBe('/fallback/workspace');
+  });
+
+  it('returns null for non-capturable contexts', () => {
+    expect(buildOpenClawHostSession({}, 'before_agent_start')).toBeNull();
+    expect(buildOpenClawHostSession(null, 'before_agent_start')).toBeNull();
+    expect(buildOpenClawHostSession({ sessionKey: 'mail:thread:abc' }, 'before_agent_start')).toBeNull();
+    expect(buildOpenClawHostSession({ sessionKey: 'subagent:agenticmail-task' }, 'before_agent_start')).toBeNull();
+  });
+});

--- a/packages/openclaw/src/host-session.ts
+++ b/packages/openclaw/src/host-session.ts
@@ -1,0 +1,82 @@
+import { saveHostSession, type HostSession } from '@agenticmail/core';
+
+export type OpenClawHostSessionSurface =
+  | 'before_agent_start'
+  | 'before_prompt_build'
+  | 'before_tool_call';
+
+type HostSessionDraft = Omit<HostSession, 'lastSeenMs'>;
+
+const SESSION_KEY_FIELDS = ['sessionKey', 'SessionKey'] as const;
+const WORKSPACE_FIELDS = ['workspace', 'cwd', 'projectRoot', 'workingDirectory'] as const;
+const MODEL_FIELDS = ['model', 'modelName'] as const;
+const AGENT_ID_FIELDS = ['agentId', 'agentID'] as const;
+const AGENT_NAME_FIELDS = ['agentName', 'name'] as const;
+const CHANNEL_FIELDS = ['channel', 'surface', 'originatingChannel', 'OriginatingChannel'] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function readStringField(record: Record<string, unknown>, fields: readonly string[]): string | undefined {
+  for (const field of fields) {
+    const value = record[field];
+    if (typeof value === 'string' && value.trim() !== '') return value.trim();
+  }
+  return undefined;
+}
+
+function withDefinedValues(values: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(values).filter(([, value]) => value !== undefined));
+}
+
+export function isOpenClawSubagentSessionKey(sessionKey: string): boolean {
+  return sessionKey.startsWith('subagent:') || sessionKey.includes(':subagent:');
+}
+
+export function isOpenClawMailChannelSessionKey(sessionKey: string): boolean {
+  return sessionKey.startsWith('mail:');
+}
+
+export function isOpenClawHostSessionKey(sessionKey: string): boolean {
+  return sessionKey !== ''
+    && !isOpenClawSubagentSessionKey(sessionKey)
+    && !isOpenClawMailChannelSessionKey(sessionKey);
+}
+
+export function buildOpenClawHostSession(
+  context: unknown,
+  surface: OpenClawHostSessionSurface,
+  fallbackWorkspace = process.cwd(),
+): HostSessionDraft | null {
+  if (!isRecord(context)) return null;
+
+  const sessionKey = readStringField(context, SESSION_KEY_FIELDS) ?? '';
+  if (!isOpenClawHostSessionKey(sessionKey)) return null;
+
+  const workspace = readStringField(context, WORKSPACE_FIELDS) ?? fallbackWorkspace;
+  const model = readStringField(context, MODEL_FIELDS);
+
+  return {
+    sessionId: sessionKey,
+    workspace,
+    model,
+    resumeMode: 'wake-only',
+    hostMetadata: withDefinedValues({
+      sessionKey,
+      surface,
+      agentId: readStringField(context, AGENT_ID_FIELDS),
+      agentName: readStringField(context, AGENT_NAME_FIELDS),
+      channel: readStringField(context, CHANNEL_FIELDS),
+    }),
+  };
+}
+
+export function recordOpenClawHostSession(
+  context: unknown,
+  surface: OpenClawHostSessionSurface,
+): void {
+  const session = buildOpenClawHostSession(context, surface);
+  if (!session) return;
+  saveHostSession('openclaw', session);
+}


### PR DESCRIPTION
## Summary
- persist OpenClaw operator session keys into the shared host-session registry
- classify OpenClaw records as wake-only so they are not treated like Claude/Codex SDK resumes
- ignore sub-agent and mail-channel session keys when recording the operator host session

## Tests
- npm test --workspace=@agenticmail/openclaw -- --run src/__tests__/host-session.test.ts
- npm test --workspace=@agenticmail/openclaw -- --run src/__tests__/spawn-timeout.test.ts
- npm test --workspace=@agenticmail/openclaw
- npm test --workspace=@agenticmail/core -- --run src/__tests__/host-sessions.test.ts
- npm run build --workspace=@agenticmail/openclaw
- npm run build --workspace=@agenticmail/core
- git diff --check

## Notes
This intentionally records OpenClaw as wake-only. OpenClaw exposes sessionKey and wake/system-event paths today, but not a durable SDK resume primitive like Claude Code or Codex.