### PR TITLE
Wake OpenClaw bridge mail via host session

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5832,7 +5832,7 @@
       "version": "0.5.63",
       "license": "MIT",
       "dependencies": {
-        "@agenticmail/core": "^0.9.11"
+        "@agenticmail/core": "^0.9.12"
       },
       "devDependencies": {
         "tsup": "^8.4.0",

--- a/packages/api/src/__tests__/security-routes.test.ts
+++ b/packages/api/src/__tests__/security-routes.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import express from 'express';
 import { createServer, type Server } from 'node:http';
 import { once } from 'node:events';
-import Database from 'better-sqlite3';
+import { DatabaseSync } from 'node:sqlite';
 import { createStorageRoutes } from '../routes/storage.js';
 
 vi.mock('@agenticmail/core', () => ({
@@ -44,7 +44,7 @@ async function request(baseUrl: string, path: string, init?: RequestInit): Promi
   return { status: res.status, body: await res.json() };
 }
 
-function createAccountApp(db: Database.Database): express.Express {
+function createAccountApp(db: DatabaseSync): express.Express {
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
@@ -55,7 +55,7 @@ function createAccountApp(db: Database.Database): express.Express {
   return app;
 }
 
-function createStorageDb(db: Database.Database) {
+function createStorageDb(db: DatabaseSync) {
   return {
     run(sql: string, params?: any[]) {
       db.prepare(sql).run(...(params ?? []));
@@ -69,7 +69,7 @@ function createStorageDb(db: Database.Database) {
   };
 }
 
-function createStorageApp(db: Database.Database): express.Express {
+function createStorageApp(db: DatabaseSync): express.Express {
   const agents: Record<string, TestAgent> = {
     owner: { id: 'owneragent000001', email: 'owner@example.com' },
     intruder: { id: 'intruderagent001', email: 'intruder@example.com' },
@@ -86,7 +86,7 @@ function createStorageApp(db: Database.Database): express.Express {
 
 describe('account route security validation', () => {
   it('rejects non-integer inactive-hours input before building SQL', async () => {
-    const db = new Database(':memory:');
+    const db = new DatabaseSync(':memory:');
     db.exec(`
       CREATE TABLE agents (
         id TEXT PRIMARY KEY,
@@ -113,7 +113,7 @@ describe('account route security validation', () => {
 
 describe('storage route SQL guards', () => {
   it('rejects unsafe filter identifiers and allows valid filters', async () => {
-    const db = new Database(':memory:');
+    const db = new DatabaseSync(':memory:');
     const baseUrl = await listen(createStorageApp(db));
 
     const created = await request(baseUrl, '/storage/tables', {
@@ -151,7 +151,7 @@ describe('storage route SQL guards', () => {
   });
 
   it('denies raw SQL access to another agent private table', async () => {
-    const db = new Database(':memory:');
+    const db = new DatabaseSync(':memory:');
     const baseUrl = await listen(createStorageApp(db));
 
     const created = await request(baseUrl, '/storage/tables', {

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -34,7 +34,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@agenticmail/core": "^0.9.11"
+    "@agenticmail/core": "^0.9.12"
   },
   "devDependencies": {
     "tsup": "^8.4.0",

--- a/packages/openclaw/src/__tests__/bridge-wake.test.ts
+++ b/packages/openclaw/src/__tests__/bridge-wake.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildOpenClawBridgeMailContext,
+  handleOpenClawBridgeWake,
+  isOpenClawBridgeAccount,
+} from '../bridge-wake.js';
+import type { HostSession } from '@agenticmail/core';
+
+describe('OpenClaw bridge wake', () => {
+  const email = {
+    from: [{ address: 'worker@localhost' }],
+    subject: 'Need operator decision',
+    text: 'Please decide this one.',
+  };
+
+  const session: HostSession = {
+    sessionId: 'agent:main',
+    lastSeenMs: Date.now() - 60_000,
+    resumeMode: 'wake-only',
+  };
+
+  it('detects the OpenClaw bridge account by name or localhost email', () => {
+    expect(isOpenClawBridgeAccount({ name: 'openclaw' })).toBe(true);
+    expect(isOpenClawBridgeAccount({ email: 'openclaw@localhost' })).toBe(true);
+    expect(isOpenClawBridgeAccount({ name: 'secretary', email: 'secretary@localhost' })).toBe(false);
+  });
+
+  it('builds shared bridge mail context from an AgenticMail message', () => {
+    expect(buildOpenClawBridgeMailContext(email, 42)).toEqual({
+      bridgeName: 'openclaw',
+      uid: 42,
+      from: 'worker@localhost',
+      subject: 'Need operator decision',
+      preview: 'Please decide this one.',
+    });
+  });
+
+  it('skips wake when the operator session is live', async () => {
+    const enqueueSystemEvent = vi.fn();
+    const outcome = await handleOpenClawBridgeWake({
+      email,
+      uid: 1,
+      runtime: { system: { enqueueSystemEvent } },
+      nowMs: 1_000,
+      loadSession: () => ({ ...session, lastSeenMs: 990 }),
+    });
+
+    expect(outcome.action).toBe('skip-live');
+    expect(enqueueSystemEvent).not.toHaveBeenCalled();
+  });
+
+  it('escalates when no fresh OpenClaw host session is known', async () => {
+    const enqueueSystemEvent = vi.fn();
+    const outcome = await handleOpenClawBridgeWake({
+      email,
+      uid: 2,
+      runtime: { system: { enqueueSystemEvent } },
+      loadSession: () => null,
+    });
+
+    expect(outcome).toEqual({ handled: true, action: 'escalate', uid: 2, reason: 'no-fresh-session' });
+    expect(enqueueSystemEvent).not.toHaveBeenCalled();
+  });
+
+  it('queues a system event against the saved OpenClaw session key', async () => {
+    const enqueueSystemEvent = vi.fn();
+    const outcome = await handleOpenClawBridgeWake({
+      email,
+      uid: 3,
+      runtime: { system: { enqueueSystemEvent } },
+      nowMs: 100_000,
+      loadSession: () => ({ ...session, lastSeenMs: 1 }),
+    });
+
+    expect(outcome).toEqual({ handled: true, action: 'wake-queued', uid: 3, sessionKey: 'agent:main' });
+    expect(enqueueSystemEvent).toHaveBeenCalledTimes(1);
+    expect(enqueueSystemEvent.mock.calls[0][0]).toContain('Bridge mail arrived');
+    expect(enqueueSystemEvent.mock.calls[0][1]).toEqual({ sessionKey: 'agent:main' });
+  });
+
+  it('dedupes in-flight wake attempts by UID', async () => {
+    const inFlightUids = new Set<number>([4]);
+    const enqueueSystemEvent = vi.fn();
+    const outcome = await handleOpenClawBridgeWake({
+      email,
+      uid: 4,
+      runtime: { system: { enqueueSystemEvent } },
+      inFlightUids,
+      loadSession: () => session,
+    });
+
+    expect(outcome).toEqual({ handled: true, action: 'duplicate', uid: 4 });
+    expect(inFlightUids.has(4)).toBe(true);
+    expect(enqueueSystemEvent).not.toHaveBeenCalled();
+  });
+
+  it('escalates when OpenClaw cannot enqueue a targeted wake event', async () => {
+    const outcome = await handleOpenClawBridgeWake({
+      email,
+      uid: 5,
+      runtime: {},
+      nowMs: 100_000,
+      loadSession: () => ({ ...session, lastSeenMs: 1 }),
+    });
+
+    expect(outcome).toEqual({ handled: true, action: 'escalate', uid: 5, reason: 'wake-unavailable' });
+  });
+});

--- a/packages/openclaw/src/bridge-wake.ts
+++ b/packages/openclaw/src/bridge-wake.ts
@@ -1,0 +1,87 @@
+import {
+  bridgeWakeLastSeenAgeMs,
+  loadHostSession,
+  planBridgeWake,
+  type BridgeMailContext,
+  type HostSession,
+} from '@agenticmail/core';
+
+export const OPENCLAW_BRIDGE_NAME = 'openclaw';
+
+export interface OpenClawBridgeIdentity {
+  name?: string;
+  email?: string;
+}
+
+export interface OpenClawBridgeWakeArgs {
+  email: any;
+  uid: number;
+  runtime?: any;
+  log?: any;
+  inFlightUids?: Set<number>;
+  nowMs?: number;
+  loadSession?: () => HostSession | null;
+}
+
+export type OpenClawBridgeWakeOutcome =
+  | { handled: true; action: 'duplicate'; uid: number }
+  | { handled: true; action: 'skip-live'; uid: number; ageMs: number }
+  | { handled: true; action: 'escalate'; uid: number; reason: 'no-fresh-session' | 'wake-unavailable' }
+  | { handled: true; action: 'wake-queued'; uid: number; sessionKey: string };
+
+export function isOpenClawBridgeAccount(identity: OpenClawBridgeIdentity): boolean {
+  const name = identity.name?.trim().toLowerCase() ?? '';
+  const email = identity.email?.trim().toLowerCase() ?? '';
+  return name === OPENCLAW_BRIDGE_NAME || email === `${OPENCLAW_BRIDGE_NAME}@localhost`;
+}
+
+export function buildOpenClawBridgeMailContext(email: any, uid: number): BridgeMailContext {
+  const from = email?.from?.[0]?.address ?? 'unknown';
+  const subject = email?.subject ?? '(no subject)';
+  const body = email?.text ?? email?.html ?? '';
+  return {
+    bridgeName: OPENCLAW_BRIDGE_NAME,
+    uid,
+    from,
+    subject,
+    preview: String(body).slice(0, 600),
+  };
+}
+
+export async function handleOpenClawBridgeWake(args: OpenClawBridgeWakeArgs): Promise<OpenClawBridgeWakeOutcome> {
+  const { uid, inFlightUids } = args;
+  if (inFlightUids?.has(uid)) {
+    args.log?.warn?.(`[agenticmail] bridge wake duplicate skipped for UID ${uid}`);
+    return { handled: true, action: 'duplicate', uid };
+  }
+
+  inFlightUids?.add(uid);
+  try {
+    const mail = buildOpenClawBridgeMailContext(args.email, uid);
+    const session = args.loadSession ? args.loadSession() : loadHostSession('openclaw');
+    const route = planBridgeWake({ session, mail, nowMs: args.nowMs });
+
+    if (route.action === 'skip-live') {
+      args.log?.info?.(`[agenticmail] bridge wake skipped; operator live (lastSeen=${route.ageMs}ms)`);
+      return { handled: true, action: 'skip-live', uid, ageMs: route.ageMs };
+    }
+
+    if (route.action === 'escalate') {
+      args.log?.warn?.(`[agenticmail] bridge wake has no fresh OpenClaw host session for UID ${uid}`);
+      return { handled: true, action: 'escalate', uid, reason: 'no-fresh-session' };
+    }
+
+    const enqueue = args.runtime?.system?.enqueueSystemEvent;
+    if (typeof enqueue !== 'function') {
+      const ageMs = bridgeWakeLastSeenAgeMs(route.session);
+      args.log?.warn?.(`[agenticmail] bridge wake cannot enqueue system event for UID ${uid} (lastSeen=${ageMs ?? 'unknown'}ms)`);
+      return { handled: true, action: 'escalate', uid, reason: 'wake-unavailable' };
+    }
+
+    await enqueue(route.prompt, { sessionKey: route.session.sessionId });
+    args.log?.info?.(`[agenticmail] bridge wake queued for OpenClaw session ${route.session.sessionId}`);
+    return { handled: true, action: 'wake-queued', uid, sessionKey: route.session.sessionId };
+  } finally {
+    inFlightUids?.delete(uid);
+  }
+}

--- a/packages/openclaw/src/channel.ts
+++ b/packages/openclaw/src/channel.ts
@@ -1,4 +1,5 @@
 import { recordInboundAgentMessage, type ToolContext } from './tools.js';
+import { handleOpenClawBridgeWake, isOpenClawBridgeAccount, type OpenClawBridgeIdentity } from './bridge-wake.js';
 
 /** Resolved mail account from OpenClaw channel config */
 export interface ResolvedMailAccount {
@@ -264,15 +265,17 @@ export function mailChannelPlugin(ctx: ToolContext): any {
           lastError: null,
         });
 
-        // Resolve our own name/address for rate limiter
-        let myName = '';
+        // Resolve our own name/address for rate limiting and bridge wake routing.
+        const myIdentity: OpenClawBridgeIdentity = {};
         try {
           const me = await mailApi(account, 'GET', '/accounts/me');
-          myName = me?.name ?? '';
+          myIdentity.name = me?.name ?? '';
+          myIdentity.email = me?.email ?? '';
         } catch { /* ignore */ }
 
         // Set of UIDs we've already dispatched (prevents re-processing)
         const processedUids = new Set<number>();
+        const inFlightBridgeWakes = new Set<number>();
 
         // Dispatch function from OpenClaw runtime
         const dispatch = runtime?.channel?.reply?.dispatchReplyWithBufferedBlockDispatcher;
@@ -283,7 +286,7 @@ export function mailChannelPlugin(ctx: ToolContext): any {
 
         // Process any unseen emails that arrived before we connected
         try {
-          await pollAndDispatch(account, cfg, dispatch, log, processedUids, myName);
+          await pollAndDispatch(account, cfg, runtime, dispatch, log, processedUids, inFlightBridgeWakes, myIdentity);
         } catch (err) {
           log?.warn?.(`[agenticmail] Initial poll error: ${(err as Error).message}`);
         }
@@ -310,7 +313,7 @@ export function mailChannelPlugin(ctx: ToolContext): any {
                     const email = await mailApi(account, 'GET', `/mail/messages/${event.uid}`);
                     if (!email) return;
 
-                    await dispatchEmail(account, cfg, dispatch, log, email, event.uid, myName);
+                    await dispatchEmail(account, cfg, runtime, dispatch, log, email, event.uid, inFlightBridgeWakes, myIdentity);
                   } catch (err) {
                     log?.warn?.(`[agenticmail] Failed to process SSE email UID ${event.uid}: ${(err as Error).message}`);
                   }
@@ -341,7 +344,7 @@ export function mailChannelPlugin(ctx: ToolContext): any {
                 const reconnectAt = Date.now() + reconnectDelay;
                 while (!abortSignal?.aborted && Date.now() < reconnectAt) {
                   try {
-                    await pollAndDispatch(account, cfg, dispatch, log, processedUids, myName);
+                    await pollAndDispatch(account, cfg, runtime, dispatch, log, processedUids, inFlightBridgeWakes, myIdentity);
                   } catch (pollErr) {
                     log?.warn?.(`[agenticmail] Poll error: ${(pollErr as Error).message}`);
                   }
@@ -387,11 +390,13 @@ export function mailChannelPlugin(ctx: ToolContext): any {
   async function dispatchEmail(
     account: ResolvedMailAccount,
     cfg: any,
+    runtime: any,
     dispatch: Function,
     log: any,
     email: any,
     uid: number,
-    myName: string,
+    inFlightBridgeWakes: Set<number>,
+    myIdentity: OpenClawBridgeIdentity,
   ): Promise<void> {
     const senderAddr: string = email.from?.[0]?.address ?? '';
     const senderName: string = email.from?.[0]?.name ?? senderAddr;
@@ -401,10 +406,21 @@ export function mailChannelPlugin(ctx: ToolContext): any {
 
     log?.info?.(`[agenticmail] ${isInterAgent ? 'Inter-agent' : 'New'} email from ${senderAddr}: ${subject}`);
 
+    if (isOpenClawBridgeAccount(myIdentity)) {
+      await handleOpenClawBridgeWake({
+        email,
+        uid,
+        runtime,
+        log,
+        inFlightUids: inFlightBridgeWakes,
+      });
+      return;
+    }
+
     // Reset rate limiter for agents who have messaged us
-    if (isInterAgent && myName) {
+    if (isInterAgent && myIdentity.name) {
       const senderLocal = senderAddr.split('@')[0] ?? '';
-      if (senderLocal) recordInboundAgentMessage(senderLocal, myName);
+      if (senderLocal) recordInboundAgentMessage(senderLocal, myIdentity.name);
     }
 
     // Build session key from thread (root message ID)
@@ -505,10 +521,12 @@ export function mailChannelPlugin(ctx: ToolContext): any {
   async function pollAndDispatch(
     account: ResolvedMailAccount,
     cfg: any,
+    runtime: any,
     dispatch: Function,
     log: any,
     processedUids: Set<number>,
-    myName: string,
+    inFlightBridgeWakes: Set<number>,
+    myIdentity: OpenClawBridgeIdentity,
   ): Promise<void> {
     const searchResult = await mailApi(account, 'POST', '/mail/search', { seen: false });
     const uids: number[] = searchResult?.uids ?? [];
@@ -522,7 +540,7 @@ export function mailChannelPlugin(ctx: ToolContext): any {
         const email = await mailApi(account, 'GET', `/mail/messages/${uid}`);
         if (!email) continue;
 
-        await dispatchEmail(account, cfg, dispatch, log, email, uid, myName);
+        await dispatchEmail(account, cfg, runtime, dispatch, log, email, uid, inFlightBridgeWakes, myIdentity);
       } catch (err) {
         log?.warn?.(`[agenticmail] Failed to process email UID ${uid}: ${(err as Error).message}`);
       }


### PR DESCRIPTION
## Summary
- route `openclaw@localhost` bridge inbox mail through the saved OpenClaw host session instead of the normal reply-dispatch channel
- queue a targeted `runtime.system.enqueueSystemEvent(..., { sessionKey })` wake when the operator is away
- skip duplicate/live-session wakes and keep bridge mail unread for the resumed operator to inspect
- require `@agenticmail/core` `^0.9.12` for the shared bridge wake helpers
- switch the API security-route test from undeclared `better-sqlite3` to Node `node:sqlite` so CI installs are reproducible

## Tests
- `npm test`
- `npm test --workspace=@agenticmail/api -- --run src/__tests__/security-routes.test.ts`
- `npm test --workspace=@agenticmail/openclaw`
- `npm test --workspace=@agenticmail/core -- --run src/__tests__/host-bridge.test.ts src/__tests__/host-sessions.test.ts`
- `npm run build --workspace=@agenticmail/api`
- `npm run build --workspace=@agenticmail/openclaw`
- `npm run build --workspace=@agenticmail/core`
- `git diff --check`
