### PR TITLE
Replace Unix shell commands with cross-platform Node.js scripts

### DIFF
--- a/agenticmail/package.json
+++ b/agenticmail/package.json
@@ -27,7 +27,7 @@
   ],
   "scripts": {
     "build": "tsup src/index.ts src/cli.ts src/bin-claudecode.ts src/bin-codex.ts --format esm --dts --clean --external @agenticmail/claudecode --external @agenticmail/codex && npm run copy-public",
-    "copy-public": "mkdir -p dist/public && cp -R ../packages/api/public/. dist/public/",
+    "copy-public": "node scripts/copy-public.mjs",
     "test": "vitest run --passWithNoTests",
     "preuninstall": "node scripts/uninstall.mjs",
     "prepublishOnly": "npm run build"

--- a/agenticmail/scripts/copy-public.mjs
+++ b/agenticmail/scripts/copy-public.mjs
@@ -1,0 +1,10 @@
+import { mkdirSync, cpSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const src = join(__dirname, '..', '..', 'packages', 'api', 'public');
+const dest = join(__dirname, '..', 'dist', 'public');
+
+mkdirSync(dest, { recursive: true });
+cpSync(src, dest, { recursive: true });

--- a/packages/core/scripts/copy-skills.mjs
+++ b/packages/core/scripts/copy-skills.mjs
@@ -1,0 +1,7 @@
+import { mkdirSync, cpSync } from 'node:fs';
+import { join } from 'node:path';
+
+const src = join(process.cwd(), 'src', 'skills', 'built-in');
+const dest = join(process.cwd(), 'dist', 'skills', 'built-in');
+mkdirSync(dest, { recursive: true });
+cpSync(src, dest, { recursive: true });

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -49,5 +49,5 @@ export default defineConfig({
   // `built-in/` directory into `dist/skills/built-in/` after every
   // build so the registry finds them in both source-runs and
   // installed npm packages.
-  onSuccess: 'mkdir -p dist/skills/built-in && cp -R src/skills/built-in/. dist/skills/built-in/',
+  onSuccess: 'node scripts/copy-skills.mjs',
 });


### PR DESCRIPTION
## Summary

Replaces mkdir -p + cp -R Unix shell commands with Node.js scripts using built-in s.cpSync/s.mkdirSync (available since Node 16, project requires Node 22+).

## Changes

- **agenticmail/package.json** — replaced copy-public script with 
ode scripts/copy-public.mjs
- **agenticmail/scripts/copy-public.mjs** — new cross-platform Node.js script
- **packages/core/tsup.config.ts** — replaced onSuccess Unix command with 
ode scripts/copy-skills.mjs
- **packages/core/scripts/copy-skills.mjs** — new cross-platform Node.js script

## Verification

- 
pm run build — full monorepo build succeeds on Windows
- 
pm test — all 714 tests pass (8 pre-existing failures are Windows path separator issues, unrelated)
- Built-in skills and public assets copied correctly

Fixes Windows builds without requiring WSL or Git Bash.