### PR TITLE
openclaw: fix port default + voice/Telegram/media/memory docs (closes #47)

### DIFF
--- a/agenticmail/README.md
+++ b/agenticmail/README.md
@@ -689,7 +689,7 @@ If you see this warning when starting the OpenClaw gateway:
 plugin id mismatch (manifest uses "agenticmail", entry hints "openclaw")
 ```
 
-This is harmless. OpenClaw infers the plugin ID from the npm package name (`@agenticmail/openclaw`) but the manifest declares `"id": "agenticmail"`. The plugin loads and works correctly.
+This warning is from older plugin installs where the manifest ID did not match the OpenClaw entry hint. Current releases use `"id": "openclaw"` and `"name": "agenticmail"`. If the warning still appears after upgrading, OpenClaw is probably loading an older global package path; run `agenticmail openclaw` or update the `plugins.load.paths` entry.
 
 ### OpenClaw plugin path not found
 
@@ -704,7 +704,7 @@ Update the path in `~/.openclaw/openclaw.json` accordingly.
 
 ### Verifying OpenClaw plugin registration
 
-`openclaw plugins inspect agenticmail` returning `Plugin not found: agenticmail` means the plugin entry hasn't been added to your `~/.openclaw/openclaw.json`. Run `agenticmail openclaw` to register it; running plain `agenticmail setup` does NOT touch your OpenClaw config — that step only fires through the explicit `openclaw` subcommand. To verify by hand: open `~/.openclaw/openclaw.json` and check that `plugins.entries` includes an entry with `"id": "agenticmail"` plus a `"path"` pointing at `<npm prefix>/lib/node_modules/@agenticmail/openclaw`.
+`openclaw plugins inspect openclaw` returning `Plugin not found: openclaw` means the plugin entry hasn't been added to your `~/.openclaw/openclaw.json`. Run `agenticmail openclaw` to register it; running plain `agenticmail setup` does NOT touch your OpenClaw config — that step only fires through the explicit `openclaw` subcommand. To verify by hand: open `~/.openclaw/openclaw.json` and check that `plugins.entries.openclaw` is enabled and `plugins.load.paths` points at `<npm prefix>/lib/node_modules/@agenticmail/openclaw`.
 
 ### `cloudflared` shows up after a localhost-only install
 

--- a/packages/openclaw/README.md
+++ b/packages/openclaw/README.md
@@ -4,15 +4,17 @@
 
 <h1 align="center">@agenticmail/openclaw</h1>
 
-[OpenClaw](https://github.com/openclaw/openclaw) plugin for [AgenticMail](https://github.com/agenticmail/agenticmail) — gives any OpenClaw agent full email and SMS capabilities, phone number access, inter-agent messaging, task coordination, and outbound security.
+[OpenClaw](https://github.com/openclaw/openclaw) plugin for [AgenticMail](https://github.com/agenticmail/agenticmail) — gives any OpenClaw agent full email, SMS, phone call-control, Telegram operator channel, media, memory, inter-agent messaging, task coordination, and outbound security.
 
-This plugin provides 63 tools, a complete email channel integration, automatic sub-agent provisioning, inter-agent message rate limiting, and a built-in follow-up system for blocked emails. It also includes a skill definition with system prompt guidelines that teach agents how to handle email professionally and securely.
+This plugin provides 89 tools, a complete email channel integration, automatic sub-agent provisioning, inter-agent message rate limiting, and a built-in follow-up system for blocked emails. It also includes a skill definition with system prompt guidelines that teach agents how to handle email, phone missions, Telegram operator escalation, memory, and media operations professionally and securely.
 
-## ✨ What's new in 0.5.60
+## What's current in 0.5.70
 
-- **`wait_for_email` filters** — block on a specific reply, not just "any new event". New params: `from`, `subject`, `inReplyTo`, `participants`, `includeTasks`. Pair with a kickoff email to wake on the exact reply you're expecting.
-
-The wake / thread-close / `check_activity` features in the main repo are Claude Code dispatcher behaviour; they don't currently apply to OpenClaw, which has its own runtime. The `wait_for_email` filter upgrade above is the OpenClaw-side win.
+- **Phone call-control tools** — OpenClaw can configure 46elks or Twilio, inspect capabilities, start policy-gated outbound call missions, read call status/transcripts, and cancel tracked missions.
+- **Realtime voice handoff** — phone missions can use transports that report `realtime_media`; the AgenticMail API owns the live OpenAI Realtime bridge, operator escalation, transcripts, skills, and provider webhooks.
+- **Telegram operator channel** — OpenClaw can configure Telegram, send operator messages, poll inbound updates, and route `ask_operator` replies back into live calls.
+- **Media and memory tools** — OpenClaw exposes TTS/voice/media helpers and persistent memory/context tools that the voice runtime can also use.
+- **Manifest guardrail** — the OpenClaw plugin manifest now tracks the npm package version in tests so plugin lists do not drift from the published package again.
 
 ## Install
 
@@ -29,13 +31,18 @@ Add to `~/.openclaw/openclaw.json`:
 ```json
 {
   "plugins": {
-    "agenticmail": {
-      "enabled": true,
-      "config": {
-        "apiUrl": "http://127.0.0.1:3829",
-        "apiKey": "ak_your_agent_key",
-        "masterKey": "mk_your_master_key"
+    "entries": {
+      "openclaw": {
+        "enabled": true,
+        "config": {
+          "apiUrl": "http://127.0.0.1:3829",
+          "apiKey": "ak_your_agent_key",
+          "masterKey": "mk_your_master_key"
+        }
       }
+    },
+    "load": {
+      "paths": ["/path/to/@agenticmail/openclaw"]
     }
   }
 }
@@ -56,6 +63,10 @@ But it goes further than just tools. The plugin also:
 - **Rate-limits inter-agent messaging** — prevents agents from flooding each other with unanswered messages (warns after 3, blocks after 5 unanswered, with a 5-minute window and 2-minute cooldown)
 - **Follows up on blocked emails** — when the outbound security guard blocks an email, the plugin automatically reminds the agent at escalating intervals to ask the human owner about approval
 - **Injects security guidelines** — the skill definition teaches agents about outbound safety (never leak API keys, passwords, PII) and inbound safety (recognize phishing, prompt injection, disguised executables)
+- **Starts guarded phone missions** — OpenClaw can call `agenticmail_call_phone` with a strict mission policy; AgenticMail handles provider webhooks, call status, transcripts, and realtime voice when the transport supports it
+- **Escalates through Telegram** — Telegram is available as a first-class operator channel for live approvals, clarifications, and call summaries
+- **Keeps durable agent context** — memory tools let agents store user preferences, call constraints, and recurring context without burying it in prompt text
+- **Exposes media primitives** — text-to-speech, voice listing, media editing/probing, video understanding, and voice cloning are available through opt-in API-backed tools
 
 ---
 
@@ -104,6 +115,24 @@ The plugin registers email as an OpenClaw channel, which means:
 - **Threading** is preserved using `In-Reply-To` and `References` headers
 - **Monitoring** uses SSE (Server-Sent Events) for instant push notifications, with a polling fallback that uses exponential backoff (2s → 4s → 8s → 16s → 30s max)
 
+### Phone Mission Flow
+
+OpenClaw does not run the live audio bridge itself. It starts and monitors phone missions through AgenticMail:
+
+```
+OpenClaw Agent → agenticmail_call_phone → AgenticMail API → phone provider webhooks → realtime voice bridge
+```
+
+The OpenClaw-side contract is:
+
+1. Check `agenticmail_phone_capabilities` before claiming calling is available.
+2. Configure the provider with `agenticmail_phone_transport_setup` if no transport is active.
+3. Start calls with `agenticmail_call_phone` and an explicit policy object that encodes duration, cost, region, recording, transcript, approval, and alternative-time limits.
+4. Use `agenticmail_call_status` and `agenticmail_call_transcript` for progress and audit.
+5. Use Telegram or email for operator clarification when the policy says `needs_operator`.
+
+The AgenticMail API owns realtime details such as OpenAI Realtime sessions, `ask_operator`, web search, memory recall, skill loading, call extension, callback scheduling, and `end_call`. OpenClaw agents should express the mission and policy, not reach around the API into provider-specific audio internals.
+
 ---
 
 ## Configuration
@@ -119,7 +148,7 @@ Plugin configuration lives in `~/.openclaw/openclaw.json` (user config), not in 
 
 ---
 
-## Tools (63 total)
+## Tools (89 total)
 
 ### Core Email (8 tools)
 
@@ -201,7 +230,7 @@ Plugin configuration lives in `~/.openclaw/openclaw.json` (user config), not in 
 | `agenticmail_submit_result` | Submit result for a claimed task |
 | `agenticmail_complete_task` | Claim and submit a task result in one call |
 
-### Account Management (6 tools)
+### Account Management (5 tools)
 
 | Tool | Description |
 |------|-------------|
@@ -210,7 +239,6 @@ Plugin configuration lives in `~/.openclaw/openclaw.json` (user config), not in 
 | `agenticmail_create_account` | Create a new agent (master key required) |
 | `agenticmail_delete_agent` | Delete an agent with email archival (master key required) |
 | `agenticmail_deletion_reports` | View past deletion reports (master key required) |
-| `agenticmail_list_agents` | Also used for account discovery |
 
 ### Gateway & Setup (9 tools)
 
@@ -297,6 +325,52 @@ Self-messaging is also prevented — an agent cannot send a message to itself.
 | `agenticmail_sms_parse_email` | Parse SMS from forwarded Google Voice email (fallback) |
 | `agenticmail_sms_config` | Get current SMS configuration |
 
+### Phone Call-Control (8 tools)
+
+| Tool | Description |
+|------|-------------|
+| `agenticmail_phone_transport_setup` | Configure 46elks or Twilio credentials, caller number, webhook base URL, webhook secret, capabilities, and supported regions |
+| `agenticmail_phone_capabilities` | Show configured phone provider, caller number, supported regions, and realtime media availability |
+| `agenticmail_call_phone` | Start a policy-gated outbound phone mission with target number, objective, region/cost/duration limits, transcript/recording flags, and operator-confirm rules |
+| `agenticmail_call_status` | Get one mission by ID or list recent phone missions |
+| `agenticmail_call_transcript` | Read transcript entries recorded for a mission |
+| `agenticmail_call_cancel` | Cancel a tracked mission in AgenticMail |
+| `agenticmail_call_open_queries` | List operator queries waiting on an answer during a live mission |
+| `agenticmail_call_answer_query` | Submit an operator answer back into a live mission |
+
+### Telegram Operator Channel (5 tools)
+
+| Tool | Description |
+|------|-------------|
+| `agenticmail_telegram_setup` | Configure a Telegram bot token, operator chat, allow-list, and poll or webhook delivery |
+| `agenticmail_telegram_config` | Show Telegram channel status and redacted configuration |
+| `agenticmail_telegram_send` | Send a Telegram message from the agent bot |
+| `agenticmail_telegram_messages` | List stored inbound and outbound Telegram messages |
+| `agenticmail_telegram_poll` | Pull Telegram updates in poll mode and ingest operator replies |
+
+### Media (9 tools)
+
+| Tool | Description |
+|------|-------------|
+| `agenticmail_media_capabilities` | Show available media providers and feature flags |
+| `agenticmail_media_tts` | Generate speech audio from text |
+| `agenticmail_media_tts_voices` | List available TTS voices |
+| `agenticmail_media_image_edit` | Edit or generate images through configured media providers |
+| `agenticmail_media_video_edit` | Edit video assets through configured media providers |
+| `agenticmail_media_audio_edit` | Edit audio assets through configured media providers |
+| `agenticmail_media_info` | Probe media metadata such as duration, dimensions, codecs, and streams |
+| `agenticmail_media_video_understand` | Analyze video content where provider support is configured |
+| `agenticmail_media_voice_clone` | Create a voice clone where provider support and policy allow it |
+
+### Memory (4 tools)
+
+| Tool | Description |
+|------|-------------|
+| `agenticmail_memory` | Set, search, get, and delete durable memory entries |
+| `agenticmail_memory_reflect` | Store reflective memory from a finished interaction |
+| `agenticmail_memory_context` | Retrieve relevant memory context for a task or call |
+| `agenticmail_memory_stats` | Inspect memory-store usage and status |
+
 ### Database Storage (1 tool)
 
 | Tool | Description |
@@ -344,8 +418,8 @@ The `openclaw.plugin.json` file registers the plugin with OpenClaw:
   "id": "openclaw",
   "name": "agenticmail",
   "displayName": "AgenticMail",
-  "version": "0.5.61",
-  "description": "Full email channel + tools for AI agents",
+  "version": "0.5.70",
+  "description": "AgenticMail — 89 tools for email, SMS, phone, Telegram, media, storage, memory & multi-agent coordination",
   "configSchema": {
     "apiUrl": { "type": "string", "default": "http://127.0.0.1:3829" },
     "apiKey": { "type": "string", "required": true },
@@ -407,7 +481,7 @@ The plugin registers three OpenClaw lifecycle hooks:
 ### Plugin ID mismatch warning
 
 ```
-plugins.entries.agenticmail: plugin agenticmail: plugin id mismatch
+plugin id mismatch
 (manifest uses "agenticmail", entry hints "openclaw")
 ```
 

--- a/packages/openclaw/REFERENCE.md
+++ b/packages/openclaw/REFERENCE.md
@@ -1,6 +1,6 @@
 # AgenticMail OpenClaw Plugin — Tool Reference
 
-> **63 tools** available via the OpenClaw plugin (`@agenticmail/openclaw`)
+> **89 tools** available via the OpenClaw plugin (`@agenticmail/openclaw`)
 
 ---
 
@@ -213,6 +213,92 @@ Parse an SMS from a forwarded Google Voice email. Use this when you receive an e
 
 ### `agenticmail_sms_config`
 Get the current SMS/phone number configuration for this agent. Secrets are redacted.
+
+## Phone Call-Control
+
+### `agenticmail_phone_transport_setup`
+Configure the phone call-control transport for this agent. Supports 46elks and Twilio credentials, caller number, webhook base URL, webhook secret, transport capabilities, and supported regions.
+
+### `agenticmail_phone_capabilities`
+Show the configured phone provider, caller number, supported regions, and whether realtime media is available.
+
+### `agenticmail_call_phone`
+Start a tracked outbound phone mission. Requires a target phone number, concrete task, and strict policy with duration, region, cost, attempts, transcript, recording, operator-confirm, and alternative-time limits.
+
+### `agenticmail_call_status`
+Get one phone mission by ID, or list recent phone missions when no ID is provided.
+
+### `agenticmail_call_transcript`
+Read the transcript entries recorded for a phone mission.
+
+### `agenticmail_call_cancel`
+Cancel a tracked phone mission in AgenticMail.
+
+### `agenticmail_call_open_queries`
+List operator queries that a live phone mission is waiting on an answer for.
+
+### `agenticmail_call_answer_query`
+Submit an operator's answer back into a live phone mission so the call can continue.
+
+## Telegram Operator Channel
+
+### `agenticmail_telegram_setup`
+Configure Telegram for this agent with a bot token, operator chat, allowed chats, and poll or webhook delivery mode.
+
+### `agenticmail_telegram_config`
+Get the current Telegram channel configuration with credentials redacted.
+
+### `agenticmail_telegram_send`
+Send a Telegram message from this agent's bot to a chat.
+
+### `agenticmail_telegram_messages`
+List stored Telegram messages for this agent.
+
+### `agenticmail_telegram_poll`
+Pull and process Telegram updates in poll mode, including operator replies to live questions.
+
+## Media
+
+### `agenticmail_media_capabilities`
+Show available media providers and feature flags.
+
+### `agenticmail_media_tts`
+Generate speech audio from text.
+
+### `agenticmail_media_tts_voices`
+List available text-to-speech voices.
+
+### `agenticmail_media_image_edit`
+Edit or generate images through configured media providers.
+
+### `agenticmail_media_video_edit`
+Edit video assets through configured media providers.
+
+### `agenticmail_media_audio_edit`
+Edit audio assets through configured media providers.
+
+### `agenticmail_media_info`
+Probe media metadata such as duration, dimensions, codecs, and streams.
+
+### `agenticmail_media_video_understand`
+Analyze video content where provider support is configured.
+
+### `agenticmail_media_voice_clone`
+Create a voice clone where provider support and policy allow it.
+
+## Memory
+
+### `agenticmail_memory`
+Set, search, get, and delete durable memory entries.
+
+### `agenticmail_memory_reflect`
+Store reflective memory from a finished interaction.
+
+### `agenticmail_memory_context`
+Retrieve relevant memory context for a task or call.
+
+### `agenticmail_memory_stats`
+Inspect memory-store usage and status.
 
 ## Database Storage
 

--- a/packages/openclaw/index.ts
+++ b/packages/openclaw/index.ts
@@ -13,6 +13,7 @@ import { setTelemetryVersion } from '@agenticmail/core';
 
 /** Default minimum timeout (seconds) for sub-agents that have email capability */
 export const DEFAULT_SUBAGENT_MIN_TIMEOUT_SECONDS = 600; // 10 minutes
+export const DEFAULT_AGENTICMAIL_API_URL = 'http://127.0.0.1:3829';
 
 export function resolveSpawnMinTimeoutSeconds(config: Record<string, unknown> | undefined): number {
   const raw = config?.spawnMinTimeoutSeconds;
@@ -243,7 +244,7 @@ function activate(api: any): void {
 
   const ctx: ToolContext = {
     config: {
-      apiUrl: pluginConfig.apiUrl ?? 'http://127.0.0.1:3100',
+      apiUrl: pluginConfig.apiUrl ?? DEFAULT_AGENTICMAIL_API_URL,
       apiKey: pluginConfig.apiKey ?? '',
       masterKey: pluginConfig.masterKey,
     },

--- a/packages/openclaw/openclaw.plugin.json
+++ b/packages/openclaw/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw",
   "name": "agenticmail",
-  "version": "0.5.68",
+  "version": "0.5.70",
   "displayName": "🎀 AgenticMail",
   "description": "🎀 AgenticMail — 89 tools for email, SMS, phone, Telegram, media, storage, memory & multi-agent coordination",
   "author": "agenticmail",
@@ -15,7 +15,7 @@
       "apiUrl": {
         "type": "string",
         "description": "AgenticMail API URL",
-        "default": "http://127.0.0.1:3100"
+        "default": "http://127.0.0.1:3829"
       },
       "apiKey": {
         "type": "string",

--- a/packages/openclaw/skill/SKILL.md
+++ b/packages/openclaw/skill/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: agenticmail
-description: 🎀 AgenticMail — Full email, SMS, storage & multi-agent coordination for AI agents. 63 tools.
+description: 🎀 AgenticMail — Full email, SMS, phone call-control, Telegram, media, memory, storage & multi-agent coordination for AI agents. 89 tools.
 homepage: https://github.com/agenticmail/agenticmail
 metadata: { "openclaw": { "emoji": "🎀", "primaryEnv": "AGENTICMAIL_API_KEY", "requires": { "bins": ["docker"], "config": ["plugins.entries.openclaw.config.apiKey"] } } }
 ---
 
 # 🎀 AgenticMail
 
-Email, SMS, database storage & multi-agent coordination for AI agents. Gives your agent a real mailbox, phone number, and persistent storage — 63 tools covering email, SMS, database management, and inter-agent task delegation. Includes outbound security guard, spam filtering, human-in-the-loop approval, and automatic follow-up scheduling.
+Email, SMS, phone call-control, Telegram, media, memory, database storage & multi-agent coordination for AI agents. Gives your agent a real mailbox, phone number, operator channel, durable context, and persistent storage — 89 tools covering email, SMS, calls, media, database management, memory, and inter-agent task delegation. Includes outbound security guard, spam filtering, human-in-the-loop approval, and automatic follow-up scheduling.
 
 ## Quick Setup
 
@@ -74,9 +74,10 @@ That's it. The command sets up the mail server, creates an agent account, config
 | `agenticmail_pending_emails` | Check status of emails blocked by outbound security guard |
 | `agenticmail_cleanup` | List or remove inactive non-persistent agent accounts |
 
-### Inter-Agent Communication (3 tools)
+### Inter-Agent Communication (4 tools)
 | Tool | Description |
 |------|-------------|
+| `agenticmail_list_agents` | List all AI agents with emails and roles |
 | `agenticmail_message_agent` | Send a message to another AI agent by name (rate-limited) |
 | `agenticmail_check_messages` | Check for new unread messages from other agents |
 | `agenticmail_wait_for_email` | Wait for a new email using push notifications (SSE) |
@@ -90,12 +91,11 @@ That's it. The command sets up the mail server, creates an agent account, config
 | `agenticmail_submit_result` | Submit result for a claimed task |
 | `agenticmail_complete_task` | Claim + submit in one call (for light-mode tasks) |
 
-### Account Management (6 tools)
+### Account Management (5 tools)
 | Tool | Description |
 |------|-------------|
 | `agenticmail_whoami` | Get current agent info (name, email, role, metadata) |
 | `agenticmail_update_metadata` | Update agent metadata |
-| `agenticmail_list_agents` | List all AI agents with emails and roles |
 | `agenticmail_create_account` | Create a new agent email account (requires master key) |
 | `agenticmail_delete_agent` | Delete an agent (archives emails, generates deletion report) |
 | `agenticmail_deletion_reports` | List or view past agent deletion reports |
@@ -124,6 +124,48 @@ That's it. The command sets up the mail server, creates an agent account, config
 | `agenticmail_sms_record` | Record an SMS from any source into the database |
 | `agenticmail_sms_parse_email` | Parse SMS from forwarded Google Voice email |
 | `agenticmail_sms_config` | Get current SMS/phone configuration |
+
+### Phone Call-Control (8 tools)
+| Tool | Description |
+|------|-------------|
+| `agenticmail_phone_transport_setup` | Configure 46elks or Twilio credentials, caller number, webhooks, capabilities, and supported regions |
+| `agenticmail_phone_capabilities` | Show configured phone provider, caller number, supported regions, and realtime-media support |
+| `agenticmail_call_phone` | Start a policy-gated outbound phone mission |
+| `agenticmail_call_status` | Get one call mission or list recent missions |
+| `agenticmail_call_transcript` | Read transcript entries for a mission |
+| `agenticmail_call_cancel` | Cancel a tracked mission |
+| `agenticmail_call_open_queries` | List operator queries waiting on an answer during a live mission |
+| `agenticmail_call_answer_query` | Submit an operator answer back into a live mission |
+
+### Telegram Operator Channel (5 tools)
+| Tool | Description |
+|------|-------------|
+| `agenticmail_telegram_setup` | Configure bot token, operator chat, allow-list, and poll or webhook delivery |
+| `agenticmail_telegram_config` | Show Telegram channel status and redacted configuration |
+| `agenticmail_telegram_send` | Send Telegram messages from the agent bot |
+| `agenticmail_telegram_messages` | List stored Telegram messages |
+| `agenticmail_telegram_poll` | Pull poll-mode Telegram updates and operator replies |
+
+### Media (9 tools)
+| Tool | Description |
+|------|-------------|
+| `agenticmail_media_capabilities` | Show available media providers and feature flags |
+| `agenticmail_media_tts` | Generate speech from text |
+| `agenticmail_media_tts_voices` | List TTS voices |
+| `agenticmail_media_image_edit` | Edit or generate images |
+| `agenticmail_media_video_edit` | Edit videos |
+| `agenticmail_media_audio_edit` | Edit audio |
+| `agenticmail_media_info` | Probe media metadata |
+| `agenticmail_media_video_understand` | Analyze video content |
+| `agenticmail_media_voice_clone` | Create a voice clone when configured and policy allows |
+
+### Memory (4 tools)
+| Tool | Description |
+|------|-------------|
+| `agenticmail_memory` | Set, search, get, and delete durable memory |
+| `agenticmail_memory_reflect` | Store reflective memory after an interaction |
+| `agenticmail_memory_context` | Retrieve relevant context for a task or call |
+| `agenticmail_memory_stats` | Inspect memory-store usage and status |
 
 ### Database Storage (1 tool, 28 actions)
 | Tool | Description |
@@ -157,6 +199,14 @@ Tables sandboxed per-agent (`agt_` prefix) or shared (`shared_` prefix). Works o
 - **Waiting for a reply?** → `agenticmail_wait_for_email` (push, not polling)
 - **Finding agents?** → `agenticmail_list_agents`
 - **Quick throwaway sub-agent?** → `sessions_spawn` is fine (only use case where it's still ok)
+
+## Phone Mission Rules
+
+- Check `agenticmail_phone_capabilities` before saying you can place calls.
+- If no phone provider is configured, use `agenticmail_phone_transport_setup` with 46elks or Twilio credentials, an owned E.164 caller number, a public HTTPS webhook base URL, and a long webhook secret.
+- Start calls with `agenticmail_call_phone`, not SMS tools. The call must include a strict `policy` object with duration, region, cost, attempts, transcript, recording, confirmation, and alternative-time limits.
+- Never provide payment details or make contractual commitments unless the call policy explicitly permits it. If policy says `needs_operator`, stop and ask the operator through the configured channel.
+- For live conversation, the AgenticMail API owns the realtime bridge and provider webhooks. Use call status and transcript tools for monitoring and audit instead of trying to control provider audio directly.
 
 ### Why 🎀 AgenticMail Is Better
 
@@ -211,10 +261,10 @@ Set in your OpenClaw config under `plugins.entries`:
 {
   "plugins": {
     "entries": {
-      "agenticmail": {
+      "openclaw": {
         "enabled": true,
         "config": {
-          "apiUrl": "http://127.0.0.1:3100",
+          "apiUrl": "http://127.0.0.1:3829",
           "apiKey": "ak_your_agent_key",
           "masterKey": "mk_your_master_key"
         }

--- a/packages/openclaw/skill/references/api-reference.md
+++ b/packages/openclaw/skill/references/api-reference.md
@@ -1,6 +1,6 @@
 # AgenticMail API Reference
 
-Base URL: `http://127.0.0.1:3100/api/agenticmail`
+Base URL: `http://127.0.0.1:3829/api/agenticmail`
 
 ## Authentication
 

--- a/packages/openclaw/skill/references/configuration.md
+++ b/packages/openclaw/skill/references/configuration.md
@@ -9,7 +9,7 @@ Run `agenticmail openclaw` to configure everything automatically.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `AGENTICMAIL_MASTER_KEY` | (generated) | Master API key |
-| `AGENTICMAIL_API_PORT` | `3100` | API server port |
+| `AGENTICMAIL_API_PORT` | `3829` | API server port |
 | `AGENTICMAIL_API_HOST` | `127.0.0.1` | API bind address |
 | `AGENTICMAIL_DATA_DIR` | `~/.agenticmail` | Data directory |
 
@@ -27,10 +27,10 @@ In `~/.openclaw/openclaw.json`:
 {
   "plugins": {
     "entries": {
-      "agenticmail": {
+      "openclaw": {
         "enabled": true,
         "config": {
-          "apiUrl": "http://127.0.0.1:3100",
+          "apiUrl": "http://127.0.0.1:3829",
           "apiKey": "ak_...",
           "masterKey": "mk_..."
         }
@@ -54,7 +54,7 @@ In `.mcp.json` (for MCP clients like Cursor, Windsurf, etc.):
       "command": "npx",
       "args": ["@agenticmail/mcp"],
       "env": {
-        "AGENTICMAIL_API_URL": "http://127.0.0.1:3100",
+        "AGENTICMAIL_API_URL": "http://127.0.0.1:3829",
         "AGENTICMAIL_API_KEY": "ak_..."
       }
     }
@@ -70,4 +70,4 @@ In `.mcp.json` (for MCP clients like Cursor, Windsurf, etc.):
 | 587 | SMTP Submission (STARTTLS) |
 | 143 | IMAP |
 | 25 | SMTP |
-| 3100 | AgenticMail API |
+| 3829 | AgenticMail API |

--- a/packages/openclaw/skill/scripts/health-check.sh
+++ b/packages/openclaw/skill/scripts/health-check.sh
@@ -9,7 +9,7 @@ fi
 
 # Check API
 API_OK=false
-if curl -sf http://127.0.0.1:3100/api/agenticmail/health > /dev/null 2>&1; then
+if curl -sf http://127.0.0.1:3829/api/agenticmail/health > /dev/null 2>&1; then
   API_OK=true
 fi
 

--- a/packages/openclaw/src/__tests__/tool-manifest.test.ts
+++ b/packages/openclaw/src/__tests__/tool-manifest.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
+import { DEFAULT_AGENTICMAIL_API_URL } from '../../index.js';
 import { registerTools } from '../tools.js';
 
 function registeredToolNames(): string[] {
@@ -17,15 +18,32 @@ function registeredToolNames(): string[] {
   return tools.sort();
 }
 
-function manifestToolNames(): string[] {
+function pluginManifest(): any {
   const manifestUrl = new URL('../../openclaw.plugin.json', import.meta.url);
-  const manifest = JSON.parse(readFileSync(manifestUrl, 'utf8'));
-  return [...manifest.tools].sort();
+  return JSON.parse(readFileSync(manifestUrl, 'utf8'));
+}
+
+function packageJson(): any {
+  const packageUrl = new URL('../../package.json', import.meta.url);
+  return JSON.parse(readFileSync(packageUrl, 'utf8'));
+}
+
+function manifestToolNames(): string[] {
+  return [...pluginManifest().tools].sort();
 }
 
 describe('OpenClaw tool manifest', () => {
   it('matches the tools registered at runtime', () => {
     expect(manifestToolNames()).toEqual(registeredToolNames());
+  });
+
+  it('keeps plugin manifest metadata in sync with the npm package', () => {
+    const manifest = pluginManifest();
+    const pkg = packageJson();
+
+    expect(manifest.version).toBe(pkg.version);
+    expect(manifest.description).toContain(`${manifest.tools.length} tools`);
+    expect(manifest.configSchema.properties.apiUrl.default).toBe(DEFAULT_AGENTICMAIL_API_URL);
   });
 
   it('exposes the Telegram channel tools', () => {


### PR DESCRIPTION
## Summary
Cherry-pick of @benediktkraus's #47 with the stale bits reconciled against current main.

- **Port `3100 → 3829`** in `openclaw.plugin.json` apiUrl default, `index.ts` runtime fallback, skill `api-reference.md`, `configuration.md`, and `health-check.sh`. Both the manifest default and the runtime fallback were live bugs — fresh OpenClaw installs were pointing at the wrong port.
- New `DEFAULT_AGENTICMAIL_API_URL` constant so the default lives in one place.
- **Docs catch-up** in README/REFERENCE/SKILL for the Phone (8), Telegram (5), Media (9), and Memory (4) tool families that had been added to the manifest without corresponding docs.
- Phone section also documents `call_open_queries` / `call_answer_query` (these landed in 0.9.97 and were not in #47).
- Manifest version bumped to **0.5.70** to match `package.json` (was drifting at 0.5.68).
- `agenticmail/README` troubleshooting copy updated to match the current `id=openclaw` / `name=agenticmail` manifest layout.
- New **drift test** in `tool-manifest.test.ts` asserts `manifest.version === package.json version`, description tool-count === `tools.length`, and apiUrl default === `DEFAULT_AGENTICMAIL_API_URL`. Next drift fails CI instead of shipping.

## Why not just merge #47
- #47 was ~16 days stale: pinned `0.5.69` (now `0.5.70`), pinned `"87 tools"` (now `89`), and its new drift test would have either failed against current main or locked in the wrong tool count.
- Two operator-query tools (`call_open_queries`, `call_answer_query`) landed after #47 was opened and were missing from its doc sections.
- This commit preserves Benedikt's structure and credits him in the body; #47 is closed via the `closes #47` reference.

## Test plan
- [x] `npm test --workspace=@agenticmail/openclaw` — 44/44 pass, including the new drift assertions
- [x] `npm run build` — clean
- [ ] CI build-and-test on this PR